### PR TITLE
Unit test to download S1-A/B SAFE file

### DIFF
--- a/tests/download_data.py
+++ b/tests/download_data.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+from urllib.request import urlopen
+
+s3_url = "http://sentinel1-slc-seasia-pds.s3-website-ap-southeast-1.amazonaws.com/datasets/slc/v1.1"
+data_info = "2021/08/15"
+granule_id = "S1A_IW_SLC__1SDV_20210815T100025_20210815T100055_039238_04A1E8_D145"
+
+
+def download_granule(in_url):
+    zip_file = in_url.split('/')[-1]
+    if os.path.isfile(zip_file) == False:
+        print(f'Start downloading of {in_url}')
+        with urlopen(in_url) as response, open(zip_file, 'wb') as ofile:
+            shutil.copyfileobj(response, ofile)
+
+
+def test_data_download():
+    '''
+    Test S1-A/B data download. Use seasia AWS s3 bucket
+    to download data. Note, it contains only data acquired
+    South East Asia, Taiwan, Korea, and Japan.
+    '''
+    # Get Full data URL
+    data_url = f'{s3_url}/{data_info}/{granule_id}/{granule_id}.zip'
+    download_granule(data_url)
+    print('Done')
+
+
+if __name__ == "__main__":
+    test_data_download()

--- a/tests/download_data.py
+++ b/tests/download_data.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-from urllib.request import urlopen
 
 s3_url = "http://sentinel1-slc-seasia-pds.s3-website-ap-southeast-1.amazonaws.com/datasets/slc/v1.1"
 data_info = "2021/08/15"
@@ -8,11 +6,10 @@ granule_id = "S1A_IW_SLC__1SDV_20210815T100025_20210815T100055_039238_04A1E8_D14
 
 
 def download_granule(in_url):
-    zip_file = in_url.split('/')[-1]
-    if os.path.isfile(zip_file) == False:
+    zip_file = os.path.basename(in_url)
+    if not os.path.isfile(zip_file):
         print(f'Start downloading of {in_url}')
-        with urlopen(in_url) as response, open(zip_file, 'wb') as ofile:
-            shutil.copyfileobj(response, ofile)
+        os.system(f'wget {in_url}')
 
 
 def test_data_download():


### PR DESCRIPTION
This PR adds a unit test to download S1-A/B data. To avoid using credential info, data are downloaded from the AWS s3 seasia bucket containing S1-A/B data covering only South East Asia.

The PR should partially address issue #10. Another PR will follow for a test downloading the XML file and test  various reader functionalities.

Note: To download approx 4 GB of data takes around 10-15 min on average. It is recommended that this test runs nightly as a part of the CI suite.