### PR TITLE
generalized SAFE and zip reader

### DIFF
--- a/bin/s1_read.py
+++ b/bin/s1_read.py
@@ -6,9 +6,9 @@ import s1reader
 if __name__ == "__main__":
     '''testing script that prints burst info and write SLC to file'''
     # TODO replace with argparse
-    zip_path = sys.argv[1]
-    if not os.path.isfile(zip_path):
-        raise FileNotFoundError(f"{zip_path} does not exist")
+    path = sys.argv[1]
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"{path} does not exist")
 
     i_subswath = int(sys.argv[2])
     if i_subswath < 1  or i_subswath > 3:
@@ -22,17 +22,19 @@ if __name__ == "__main__":
     orbit_dir = sys.argv[4]
     if not os.path.isdir(orbit_dir):
         raise NotADirectoryError(f"{orbit_dir} not found")
-    orbit_path = s1reader.get_orbit_file_from_dir(zip_path, orbit_dir)
+    orbit_path = s1reader.get_orbit_file_from_dir(path, orbit_dir)
 
-    bursts = s1reader.burst_from_zip(zip_path, orbit_path, i_subswath, pol)
+    bursts = s1reader.load_burst(path, orbit_path, i_subswath, pol)
 
     # print out IDs and lat/lon centers of all bursts
     for i, burst in enumerate(bursts):
         print(burst.burst_id, burst.center)
 
     # write to ENVI (default)
+    '''
     burst.slc_to_file('burst.slc')
     # write to geotiff
     burst.slc_to_file('burst.tif', 'GTiff')
     # write to VRT
     burst.slc_to_file('burst.vrt', 'VRT')
+    '''

--- a/bin/s1_read.py
+++ b/bin/s1_read.py
@@ -31,10 +31,8 @@ if __name__ == "__main__":
         print(burst.burst_id, burst.center)
 
     # write to ENVI (default)
-    '''
     burst.slc_to_file('burst.slc')
     # write to geotiff
     burst.slc_to_file('burst.tif', 'GTiff')
     # write to VRT
     burst.slc_to_file('burst.vrt', 'VRT')
-    '''

--- a/bin/s1_read.py
+++ b/bin/s1_read.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         raise NotADirectoryError(f"{orbit_dir} not found")
     orbit_path = s1reader.get_orbit_file_from_dir(path, orbit_dir)
 
-    bursts = s1reader.load_burst(path, orbit_path, i_subswath, pol)
+    bursts = s1reader.load_bursts(path, orbit_path, i_subswath, pol)
 
     # print out IDs and lat/lon centers of all bursts
     for i, burst in enumerate(bursts):

--- a/src/s1reader/__init__.py
+++ b/src/s1reader/__init__.py
@@ -1,4 +1,4 @@
 # top-level functions to be easily used
 from .s1_burst_slc import Sentinel1BurstSlc
-from .s1_reader import burst_from_zip, burst_from_xml
+from .s1_reader import load_burst
 from .s1_orbit import get_orbit_file_from_dir

--- a/src/s1reader/__init__.py
+++ b/src/s1reader/__init__.py
@@ -1,4 +1,4 @@
 # top-level functions to be easily used
 from .s1_burst_slc import Sentinel1BurstSlc
-from .s1_reader import load_burst
+from .s1_reader import load_bursts
 from .s1_orbit import get_orbit_file_from_dir

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 import datetime
 import tempfile
+import warnings
 
 import isce3
 import numpy as np
@@ -184,7 +185,7 @@ class Sentinel1BurstSlc:
     border: list # list of lon, lat coordinate tuples (in degrees) representing burst border
     orbit: isce3.core.Orbit
     # VRT params
-    tiff_path: str  # path to tiff in SAFE zip
+    tiff_path: str  # path to measurement tiff in SAFE/zip
     i_burst: int
     first_valid_sample: int
     last_valid_sample: int
@@ -232,6 +233,11 @@ class Sentinel1BurstSlc:
         out_path : string
             Path of output GTiff file.
         '''
+        if not self.tiff_path:
+            warn_str = f'Unable write SLC to file. Burst does not contain image data; only metadata.'
+            warnings.warn(warn_str)
+            return
+
         # get output directory of out_path
         dst_dir, _ = os.path.split(out_path)
 
@@ -262,6 +268,11 @@ class Sentinel1BurstSlc:
         out_path : string
             Path of output VRT file.
         '''
+        if not self.tiff_path:
+            warn_str = f'Unable write SLC to file. Burst does not contain image data; only metadata.'
+            warnings.warn(warn_str)
+            return
+
         line_offset = self.i_burst * self.shape[0]
 
         inwidth = self.last_valid_sample - self.first_valid_sample + 1

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -60,7 +60,7 @@ def get_orbit_file_from_list(zip_path: str, orbit_file_list: list[str]) -> str:
     orbit_path : str
         Path the orbit file.
     '''
-    if not os.path.isfile(zip_path):
+    if not os.path.exists(zip_path):
         raise FileNotFoundError(f"{zip_path} does not exist")
 
     if not orbit_file_list:
@@ -92,13 +92,13 @@ def get_orbit_file_from_list(zip_path: str, orbit_file_list: list[str]) -> str:
 
     return ''
 
-def get_orbit_file_from_dir(zip_path: str, orbit_dir: str) -> str:
+def get_orbit_file_from_dir(path: str, orbit_dir: str) -> str:
     '''Get orbit state vector list for a given swath.
 
     Parameters:
     -----------
-    zip_path : string
-        Path to Sentinel1 SAFE zip file. File names required to adhere to the
+    path : string
+        Path to Sentinel1 SAFE zip file. Base names required to adhere to the
         format described here:
         https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/naming-conventions
     orbit_dir : string
@@ -111,13 +111,13 @@ def get_orbit_file_from_dir(zip_path: str, orbit_dir: str) -> str:
     orbit_path : str
         Path the orbit file.
     '''
-    if not os.path.isfile(zip_path):
-        raise FileNotFoundError(f"{zip_path} does not exist")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"{path} does not exist")
 
     if not os.path.isdir(orbit_dir):
         raise NotADirectoryError(f"{orbit_dir} not found")
 
     orbit_path = get_orbit_file_from_list(
-        zip_path, [f'{orbit_dir}/{item}' for item in os.listdir(orbit_dir)])
+        path, [f'{orbit_dir}/{item}' for item in os.listdir(orbit_dir)])
 
     return orbit_path

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -407,7 +407,7 @@ def _is_zip_annotation_xml(path: str, id_str: str) -> bool:
         return True
     return False
 
-def load_burst(path: str, orbit_path: str, swath_num: int, pol: str = 'vv'):
+def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str = 'vv'):
     '''Find bursts in a Sentinel 1 zip file or a SAFE structured directory.
 
     Parameters:

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import warnings
 import xml.etree.ElementTree as ET
 import zipfile
 
@@ -506,11 +507,16 @@ def _burst_from_safe_dir(safe_dir_path: str, id_str: str, orbit_path: str):
         raise ValueError(f"burst {id_str} not in SAFE: {safe_dir_path}")
     f_annotation = f'{safe_dir_path}/annotation/{f_annotation[0]}'
 
-    # find tiff file
-    measurement_list = os.listdir(f'{safe_dir_path}/measurement')
-    f_tiff = [f for f in measurement_list
-              if 'measurement' in f and id_str in f and 'tiff' in f]
-    f_tiff = f'{safe_dir_path}/measurement/{f_tiff[0]}' if f_tiff else ''
+    # find tiff file if measurement directory found
+    if os.path.isdir(f'{safe_dir_path}/measurement'):
+        measurement_list = os.listdir(f'{safe_dir_path}/measurement')
+        f_tiff = [f for f in measurement_list
+                  if 'measurement' in f and id_str in f and 'tiff' in f]
+        f_tiff = f'{safe_dir_path}/measurement/{f_tiff[0]}' if f_tiff else ''
+    else:
+        warning_str = f'measurement directory not found in {safe_dir_path}'
+        warnings.warn(warning_str)
+        f_tiff = ''
 
     bursts = burst_from_xml(f_annotation, orbit_path, f_tiff)
     return bursts


### PR DESCRIPTION
This PR addresses #22 by adding a public-facing, generalized `load_bursts` method that:
1. loads from both zip and SAFE, 
2. doesn't require a tiff file to be found/included.

It is intended to replace the current public-facing `bursts_from_zip` method.