### PR TITLE
README: add license and pre-alpha warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## s1-reader
+
+A package to read Sentinel-1 data into the ISCE3-compatible burst class.
+
 ### Features
 
 + Create ISCE3-compatible Sentinel1 burst class given:
@@ -8,6 +12,8 @@
   - path to orbit directory
 
 + Monotonically increasing bursts IDs.
+
+🚨 This toolbox is still in **pre-alpha** stage and undergoing **rapid development**. 🚨 
 
 ### Install
 
@@ -48,3 +54,33 @@ orbit_path = s1reader.get_orbit_file_from_dir(zip_path, orbit_dir)
 # returns the list of the bursts
 bursts = s1reader.burst_from_zip(zip_path, orbit_path, swath_num, pol)
 ```
+
+### License
+
+**Copyright (c) 2021** California Institute of Technology (“Caltech”). U.S. Government
+sponsorship acknowledged.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this list of conditions and
+the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Caltech nor its operating division, the Jet Propulsion Laboratory, nor the
+names of its contributors may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -57,21 +57,14 @@ bursts = s1reader.burst_from_zip(zip_path, orbit_path, swath_num, pol)
 
 ### License
 
-**Copyright (c) 2021** California Institute of Technology (“Caltech”). U.S. Government
-sponsorship acknowledged.
+**Copyright (c) 2021** California Institute of Technology (“Caltech”). U.S. Government sponsorship acknowledged.
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided
-that the following conditions are met:
-* Redistributions of source code must retain the above copyright notice, this list of conditions and
-the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions
-and the following disclaimer in the documentation and/or other materials provided with the
-distribution.
-* Neither the name of Caltech nor its operating division, the Jet Propulsion Laboratory, nor the
-names of its contributors may be used to endorse or promote products derived from this software
-without specific prior written permission.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Neither the name of Caltech nor its operating division, the Jet Propulsion Laboratory, nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+python>=3.9
 numpy
 gdal
-isce3
+#isce3  #comment out temporarily as conda installed version does not work
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python>=3.9
 numpy
 gdal
-#isce3    # [temporary] install isce3 from stratch instead, to stay in sync with isce3 development.
+#isce3    # since the conda-installed isce3 is not the most updated version, installing isce3 from stratch is recommended, to stay in sync with isce3 development.
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python>=3.9
 numpy
 gdal
-#isce3  #comment out temporarily as conda installed version does not work
+#isce3    # [temporary] install isce3 from stratch instead, to stay in sync with isce3 development.
 shapely


### PR DESCRIPTION
+ README: 
   - add license info, to be consistent with other opera-adt repos.
   - and pre-alpha warning msg.

+ requirements:
   - add `python>=3.9` to be consistent with `setup.cfg`
   - comment out `isce3` as conda installed version does not work yet.