### PR TITLE
extract rank and prf

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -195,8 +195,8 @@ class Sentinel1BurstSlc:
     # window parameters
     range_window_type: str
     range_window_coefficient: float
-    rank: int # The number of PRI between transmitted pulse and return echo. 
-    prf_raw_data: float  # Pulse repetition frequency (PRF) of the raw data [Hz] 
+    rank: int # The number of PRI between transmitted pulse and return echo.
+    prf_raw_data: float  # Pulse repetition frequency (PRF) of the raw data [Hz]
 
     def as_isce3_radargrid(self):
         '''Init and return isce3.product.RadarGridParameters.

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -195,7 +195,8 @@ class Sentinel1BurstSlc:
     # window parameters
     range_window_type: str
     range_window_coefficient: float
-
+    rank: int # The number of PRI between transmitted pulse and return echo. 
+    prf_raw_data: float  # Pulse repetition frequency (PRF) of the raw data [Hz] 
 
     def as_isce3_radargrid(self):
         '''Init and return isce3.product.RadarGridParameters.

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -293,7 +293,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
         ascending_node_time = as_datetime(image_info_element.find('ascendingNodeTime').text)
-       
+
         downlink_element =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
         prf_raw_data = float(downlink_element.find('prf').text)
         rank = int(downlink_element.find('downlinkValues/rank').text)
@@ -388,7 +388,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       boundary_pts[i], orbit, orbit_direction,
                                       tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
-                                      range_window_type, range_window_coeff, 
+                                      range_window_type, range_window_coeff,
                                       rank, prf_raw_data)
 
     return bursts

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -293,6 +293,12 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
         ascending_node_time = as_datetime(image_info_element.find('ascendingNodeTime').text)
+       
+        downlink_info =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
+        prf_raw_data = float(downlink_info.find('prf').text)
+        downlink_values =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation/downlinkValues')
+        rank = int(downlink_values.find('rank').text)
+
 
         n_lines = int(tree.find('swathTiming/linesPerBurst').text)
         n_samples = int(tree.find('swathTiming/samplesPerBurst').text)
@@ -384,7 +390,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       boundary_pts[i], orbit, orbit_direction,
                                       tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
-                                      range_window_type, range_window_coeff)
+                                      range_window_type, range_window_coeff, rank, prf_raw_data)
 
     return bursts
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -294,11 +294,9 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
         ascending_node_time = as_datetime(image_info_element.find('ascendingNodeTime').text)
        
-        downlink_info =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
-        prf_raw_data = float(downlink_info.find('prf').text)
-        downlink_values =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation/downlinkValues')
-        rank = int(downlink_values.find('rank').text)
-
+        downlink_element =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
+        prf_raw_data = float(downlink_element.find('prf').text)
+        rank = int(downlink_element.find('downlinkValues/rank').text)
 
         n_lines = int(tree.find('swathTiming/linesPerBurst').text)
         n_samples = int(tree.find('swathTiming/samplesPerBurst').text)
@@ -390,7 +388,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       boundary_pts[i], orbit, orbit_direction,
                                       tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
-                                      range_window_type, range_window_coeff, rank, prf_raw_data)
+                                      range_window_type, range_window_coeff, 
+                                      rank, prf_raw_data)
 
     return bursts
 


### PR DESCRIPTION
This PR extracts two more parameters called rank and prf. Even though Sentinel-1 Spec uses the short name prf I chose prf_raw_data to clarify that this prf is raw data prf and does not equal to the inverse of SLC azimuth_time_interval. 