### PR TITLE
Bistatic delay

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -438,9 +438,9 @@ class Sentinel1BurstSlc:
 
         Returns
         --------
-           bistatic delay correction in seconds. This correction needs to be 
-           added to the SLC tagged azimuth time to get the corrected azimuth
-           times.
+           LUT2D object of bistatic delay correction in seconds as a function
+           of the range and zimuth indices. This correction needs to be added 
+           to the SLC tagged azimuth time to get the corrected azimuth times.
         '''
 
         pri = 1.0 / self.prf_raw_data

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -423,6 +423,23 @@ class Sentinel1BurstSlc:
             self_as_dict[key] = val
         return self_as_dict
 
+    def bistatic_delay(self, xstep=1, ystep=1):
+        pri = 1.0 / self.prf_raw_data
+        tau0 = self.rank * pri
+
+        mid_range = self.starting_range + 0.5 * self.width * self.range_pixel_spacing
+        tau_mid = mid_range * 2.0 / isce3.core.speed_of_light
+
+        x = np.arange(0, self.width, xstep, dtype=int)
+        y = np.arange(0, self.length, ystep, dtype=int)
+        x_mesh, y_mesh = np.meshgrid(x, y)
+        slant_range = self.starting_range + x_mesh * self.range_pixel_spacing
+        tau = slant_range * 2.0 / isce3.core.speed_of_light
+
+        bistatic_correction = tau_mid / 2 + tau / 2 - tau0
+
+        return bistatic_correction
+
     @property
     def sensing_mid(self):
         '''Returns sensing mid as datetime.datetime object.

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -437,7 +437,7 @@ class Sentinel1BurstSlc:
 
 
         Returns
-        --------
+        -------
            LUT2D object of bistatic delay correction in seconds as a function
            of the range and zimuth indices. This correction needs to be added
            to the SLC tagged azimuth time to get the corrected azimuth times.

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -449,8 +449,11 @@ class Sentinel1BurstSlc:
         mid_range = self.starting_range + 0.5 * self.width * self.range_pixel_spacing
         tau_mid = mid_range * 2.0 / isce3.core.speed_of_light
 
-        x = np.arange(0, self.width, xstep, dtype=int)
-        y = np.arange(0, self.length, ystep, dtype=int)
+        nx = int(self.width / xstep)
+        ny = int(self.length / ystep)
+
+        x = np.arange(0, (nx+1)*xstep, xstep, dtype = int)
+        y = np.arange(0, (ny+1)*ystep, ystep, dtype = int)
         x_mesh, y_mesh = np.meshgrid(x, y)
         slant_range = self.starting_range + x_mesh * self.range_pixel_spacing
         tau = slant_range * 2.0 / isce3.core.speed_of_light
@@ -466,7 +469,8 @@ class Sentinel1BurstSlc:
         # correction and our assumed middle of the burst of interest.
         bistatic_correction = tau_mid / 2 + tau / 2 - tau0
 
-        return bistatic_correction
+        return isce3.core.LUT2d(x, y, bistatic_correction)
+
 
     @property
     def sensing_mid(self):

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -439,7 +439,7 @@ class Sentinel1BurstSlc:
         Returns
         --------
            LUT2D object of bistatic delay correction in seconds as a function
-           of the range and zimuth indices. This correction needs to be added 
+           of the range and zimuth indices. This correction needs to be added
            to the SLC tagged azimuth time to get the corrected azimuth times.
         '''
 
@@ -454,18 +454,18 @@ class Sentinel1BurstSlc:
 
         x = np.arange(0, (nx+1)*xstep, xstep, dtype = int)
         y = np.arange(0, (ny+1)*ystep, ystep, dtype = int)
-        x_mesh, y_mesh = np.meshgrid(x, y)
+        x_mesh = np.meshgrid(x, y)[0]
         slant_range = self.starting_range + x_mesh * self.range_pixel_spacing
         tau = slant_range * 2.0 / isce3.core.speed_of_light
 
         # the first term (tau_mid/2) is the bulk bistatic delay which was
         # removed from the orginial azimuth time by the ESA IPF. Based on
-        # Gisinger et al, 2021, ESA IPF has used the mid of the second subswath 
-        # to compute the bulk bistatic delay. However currently we have not 
+        # Gisinger et al, 2021, ESA IPF has used the mid of the second subswath
+        # to compute the bulk bistatic delay. However currently we have not
         # been able to verify this from ESA documents. In this implementation
-        # we have used the range to the middle of the burst of interest to 
+        # we have used the range to the middle of the burst of interest to
         # compute the bulk bistatic delay. The correction can be potentially
-        # biased by the amount of discrepancy between the ESA IPF bulk bistatic 
+        # biased by the amount of discrepancy between the ESA IPF bulk bistatic
         # correction and our assumed middle of the burst of interest.
         bistatic_correction = tau_mid / 2 + tau / 2 - tau0
 


### PR DESCRIPTION
This PR adds a method to the BurstSLC class to compute bistatic delay as described by [Gisinger et al 2021](https://ieeexplore.ieee.org/abstract/document/9115211). I have tried to put documentation in the code for a caveat about unclear initial bulk bistatic delay correction applied by ESA. At the moment I don't have a clear evidence if ESA has used the middle of the busrt of interest to compute their approximate bulk bistatic delay or the middle of the subswath 2. The latter has been mentioned by Gisinegr et al , but was not found in any ESA document so far. 