### PR TITLE
add burst metadata: burst_duration & swath_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ orbit_dir = '/home/user/data/sentinel1_orbits'
 orbit_path = s1reader.get_orbit_file_from_dir(zip_path, orbit_dir)
 
 # returns the list of the bursts
-bursts = s1reader.burst_from_zip(zip_path, orbit_path, swath_num, pol)
+bursts = s1reader.load_bursts(zip_path, orbit_path, swath_num, pol)
+burst_ids = [x.burst_id for x in bursts]
 ```
 
 ### License

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -448,9 +448,26 @@ class Sentinel1BurstSlc:
         return self.sensing_start + datetime.timedelta(seconds=d_seconds)
 
     @property
+    def burst_duration(self):
+        '''Returns burst sensing duration as float in seconds.
+
+        Returns:
+        --------
+        _ : float
+            Burst sensing duration as float in seconds.
+        '''
+        return self.azimuth_time_interval * self.shape[0]
+
+    @property
     def length(self):
         return self.shape[0]
 
     @property
     def width(self):
         return self.shape[1]
+
+    @property
+    def swath_name(self):
+    '''Swath name in iw1, iw2, iw3.'''
+        return self.burst_id.split('_')[1]
+

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -456,7 +456,7 @@ class Sentinel1BurstSlc:
         _ : float
             Burst sensing duration as float in seconds.
         '''
-        return self.azimuth_time_interval * self.shape[0]
+        return self.azimuth_time_interval * self.length
 
     @property
     def length(self):

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -468,6 +468,6 @@ class Sentinel1BurstSlc:
 
     @property
     def swath_name(self):
-    '''Swath name in iw1, iw2, iw3.'''
+        '''Swath name in iw1, iw2, iw3.'''
         return self.burst_id.split('_')[1]
 


### PR DESCRIPTION
This PR adds two more metadata to the burst class.

+ s1_slc_burst: add two more metadata:
   - burst_duration
   - swath_name

+ README: update usage to load_bursts()