### PR TITLE
Doppler shift

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -458,13 +458,13 @@ class Sentinel1BurstSlc:
 
         Returns
         -------
-        1D array: int
-           The index of samples in range direction
-        1D array: int
-           The index of samples in azimuth direction
-        2D array: float
+        x : int
+           The index of samples in range direction as an 1D array
+        y : int
+           The index of samples in azimuth direction as an 1D array
+        total_doppler : float
            Total Doppler which is the sum of the geometrical Doppler and
-           beam steering induced Doppler [Hz]
+           beam steering induced Doppler [Hz] as a 2D array
         """
 
         x = np.arange(0, self.width, xstep, dtype=int)

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -111,11 +111,11 @@ class AzimuthCarrierComponents:
     eta_ref: float
 
     @property
-    antenna_steering_doppler(self):
+    def antenna_steering_doppler(self):
         return self.kt * (self.eta - self.eta_ref)
 
     @property
-    carrier(self):
+    def carrier(self):
         return np.pi * self.kt * ((self.eta - self.eta_ref) ** 2)
 
 @dataclass(frozen=True)

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -195,7 +195,8 @@ class Sentinel1BurstSlc:
     # window parameters
     range_window_type: str
     range_window_coefficient: float
-
+    rank: int # The number of PRI between transmitted pulse and return echo.
+    prf_raw_data: float  # Pulse repetition frequency (PRF) of the raw data [Hz]
 
     def as_isce3_radargrid(self):
         '''Init and return isce3.product.RadarGridParameters.

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -536,10 +536,10 @@ class Sentinel1BurstSlc:
         '''
         # Get self.sensing mid relative to orbit reference epoch
         fmt = "%Y-%m-%dT%H:%M:%S.%f"
-        orbit_ref_epoch = datetime.datetime.strptime(orbit.reference_epoch.__str__()[:-3], fmt)
+        orbit_ref_epoch = datetime.datetime.strptime(self.orbit.reference_epoch.__str__()[:-3], fmt)
 
         t_mid = self.sensing_mid - orbit_ref_epoch
-        _, v = orbit.interpolate(t_mid.total_seconds())
+        _, v = self.orbit.interpolate(t_mid.total_seconds())
         vs = np.linalg.norm(v)
         ks = 2 * vs * self.azimuth_steer_rate / self.wavelength
 

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -389,7 +389,7 @@ class Sentinel1BurstSlc:
 
         return az_carrier_poly
 
-    def total_doppler(self, xstep=500, ystep=50):
+    def geometrical_and_steering_doppler(self, xstep=500, ystep=50):
         """
         Compute total Doppler which is the sum of two components: 
         (1) the geometrical Doppler induced by the relative movement 
@@ -406,10 +406,15 @@ class Sentinel1BurstSlc:
 
         Returns
         -------
+        1D array: int
+           The index of samples in range direction
+        1D array: int
+           The index of samples in azimuth direction
         2D array: float
            Total Doppler which is the sum of the geometrical Doppler and 
            beam steering induced Doppler [Hz]
         """
+
         x = np.arange(0, self.width, xstep, dtype=int)
         y = np.arange(0, self.length, ystep, dtype=int)
         x_mesh, y_mesh = np.meshgrid(x, y)
@@ -422,11 +427,11 @@ class Sentinel1BurstSlc:
         slant_range = self.starting_range + x * self.range_pixel_spacing
         geometrical_doppler = self.doppler.poly1d.eval(slant_range)
 
-        total_Doppler = antenna_steering_Doppler + geometrical_doppler
+        total_doppler = antenna_steering_Doppler + geometrical_doppler
 
-        return x, y, total_Doppler
+        return x, y, total_doppler
 
-    def range_delay_caused_by_doppler_shift(self, xstep=500, ystep=50):
+    def doppler_induced_range_shift(self, xstep=500, ystep=50):
         """
         Computes the range delay caused by the Doppler shift as described 
         by Gisinger et al 2021
@@ -446,7 +451,8 @@ class Sentinel1BurstSlc:
 
         """
 
-        x, y, doppler_shift = self.total_doppler(xstep=xstep, ystep=ystep)
+        x, y, doppler_shift = self.geometrical_and_steering_doppler(
+                                                    xstep=xstep, ystep=ystep)
         tau_corr = doppler_shift / self.range_chirp_rate
 
         return isce3.core.LUT2d(x, y, tau_corr)

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -35,7 +35,7 @@ def compute_az_carrier(burst, orbit, offset, position):
     fmt = "%Y-%m-%dT%H:%M:%S.%f"
     orbit_ref_epoch = datetime.datetime.strptime(orbit.reference_epoch.__str__()[:-3], fmt)
 
-    t_mid = burst.get_sensing_mid() - orbit_ref_epoch
+    t_mid = burst.sensing_mid - orbit_ref_epoch
     _, v = orbit.interpolate(t_mid.total_seconds())
     vs = np.linalg.norm(v)
     ks = 2 * vs * burst.azimuth_steer_rate / burst.wavelength
@@ -184,6 +184,7 @@ class Sentinel1BurstSlc:
     center: tuple # {center lon, center lat} in degrees
     border: list # list of lon, lat coordinate tuples (in degrees) representing burst border
     orbit: isce3.core.Orbit
+    orbit_direction: str
     # VRT params
     tiff_path: str  # path to measurement tiff in SAFE/zip
     i_burst: int

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -297,6 +297,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         downlink_element =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
         prf_raw_data = float(downlink_element.find('prf').text)
         rank = int(downlink_element.find('downlinkValues/rank').text)
+        range_chirp_ramp_rate = float(downlink_element.find('downlinkValues/txPulseRampRate').text)
 
         n_lines = int(tree.find('swathTiming/linesPerBurst').text)
         n_samples = int(tree.find('swathTiming/samplesPerBurst').text)
@@ -389,8 +390,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
                                       range_window_type, range_window_coeff,
-                                      rank, prf_raw_data)
-
+                                      rank, prf_raw_data, range_chirp_ramp_rate)
+        
     return bursts
 
 def _is_zip_annotation_xml(path: str, id_str: str) -> bool:

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -287,6 +287,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         azimuth_steer_rate = np.radians(float(product_info_element.find('azimuthSteeringRate').text))
         radar_freq = float(product_info_element.find('radarFrequency').text)
         range_sampling_rate = float(product_info_element.find('rangeSamplingRate').text)
+        orbit_direction = product_info_element.find('pass').text
 
         image_info_element = tree.find('imageAnnotation/imageInformation')
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
@@ -379,8 +380,9 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       range_sampling_rate, range_pxl_spacing,
                                       (n_lines, n_samples), az_fm_rate, doppler,
                                       rng_processing_bandwidth, pol, burst_id,
-                                      platform_id, center_pts[i], boundary_pts[i],
-                                      orbit, tiff_path, i, first_valid_sample,
+                                      platform_id, center_pts[i],
+                                      boundary_pts[i], orbit, orbit_direction,
+                                      tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
                                       range_window_type, range_window_coeff)
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -294,6 +294,10 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
         ascending_node_time = as_datetime(image_info_element.find('ascendingNodeTime').text)
 
+        downlink_element =  tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
+        prf_raw_data = float(downlink_element.find('prf').text)
+        rank = int(downlink_element.find('downlinkValues/rank').text)
+
         n_lines = int(tree.find('swathTiming/linesPerBurst').text)
         n_samples = int(tree.find('swathTiming/samplesPerBurst').text)
 
@@ -384,7 +388,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       boundary_pts[i], orbit, orbit_direction,
                                       tiff_path, i, first_valid_sample,
                                       last_sample, first_valid_line, last_line,
-                                      range_window_type, range_window_coeff)
+                                      range_window_type, range_window_coeff,
+                                      rank, prf_raw_data)
 
     return bursts
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -401,7 +401,6 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                       last_sample, first_valid_line, last_line,
                                       range_window_type, range_window_coeff,
                                       rank, prf_raw_data, range_chirp_ramp_rate)
-        
     return bursts
 
 def _is_zip_annotation_xml(path: str, id_str: str) -> bool:


### PR DESCRIPTION
This PR add functionality to compute range delay caused by Doppler shift as described by Gisinger et al 2021.
Note that to be able to reuse some the Carrier computation function that we had, I had to break it to two functions, one to compute Kt and one that computes the carrier and converts to phase in radian.  