### PR TITLE
fix partial IDs found

### DIFF
--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -488,8 +488,8 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
             warnings.warn("None of provided burst IDs found in sub-swath {swath_num}")
         elif burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
-            warn_str = f'Not all burst IDs found. \n '
-            warn_str += f'Not found: {diff} . \n' 
+            warn_str = 'Not all burst IDs found. \n '
+            warn_str += f'Not found: {diff} . \n'
             warn_str += f'Found bursts: {burst_ids_found}'
             warnings.warn(warn_str)
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -482,11 +482,11 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
 
         burst_ids_found = set([b.burst_id for b in bursts])
 
+        warnings.simplefilter("always")
+        set_burst_ids = set(burst_ids)
         if not burst_ids_found:
             warnings.warn("None of provided bursts IDs found")
-
-        set_burst_ids = set(burst_ids)
-        if burst_ids_found and burst_ids_found != set_burst_ids:
+        elif burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
             warn_str = f'Not all burst IDs found. Not found: {diff}. '
             warn_str += f'Found: {burst_ids_found}'

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -485,7 +485,7 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
         warnings.simplefilter("always")
         set_burst_ids = set(burst_ids)
         if not burst_ids_found:
-            warnings.warn("None of provided bursts IDs found")
+            warnings.warn("None of provided burst IDs found in sub-swath {swath_num}")
         elif burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
             warn_str = f'Not all burst IDs found. Not found: {diff}. '

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -488,7 +488,8 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
             warnings.warn("None of provided burst IDs found in sub-swath {swath_num}")
         elif burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
-            warn_str = f'Not all burst IDs found. Not found: {diff}. '
+            warn_str = f'Not all burst IDs found. \n '
+            warn_str += f'Not found: {diff} . \n' 
             warn_str += f'Found bursts: {burst_ids_found}'
             warnings.warn(warn_str)
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -486,7 +486,7 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
             warnings.warn("None of provided bursts IDs found")
 
         set_burst_ids = set(burst_ids)
-        if burst_ids_found != set_burst_ids:
+        if burst_ids_found and burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
             warn_str = f'Not all burst IDs found. Not found: {diff}. '
             warn_str += f'Found: {burst_ids_found}'

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -489,7 +489,7 @@ def load_bursts(path: str, orbit_path: str, swath_num: int, pol: str='vv',
         elif burst_ids_found != set_burst_ids:
             diff = set_burst_ids.difference(burst_ids_found)
             warn_str = f'Not all burst IDs found. Not found: {diff}. '
-            warn_str += f'Found: {burst_ids_found}'
+            warn_str += f'Found bursts: {burst_ids_found}'
             warnings.warn(warn_str)
 
     return bursts


### PR DESCRIPTION
This PR fixes a bug In #37 when no burst IDs were found but partial find warning given.

In both calls below, 9 is not a valid ID.
```python
s1reader.load_bursts(path, orbit_path, i_subswath, pol, [9, 't71_iw2_b844'])
s1reader.load_bursts(path, orbit_path, i_subswath, pol, 9)
```
The resulting warnings are:
```bash
/home/lyu/miniconda3/envs/OPERA/lib/python3.9/site-packages/s1reader/s1_reader.py:493: UserWarning: Not all burst IDs found. Not found: {9}. Found: {'t71_iw2_b844'}
  warnings.warn(warn_str)
/home/lyu/miniconda3/envs/OPERA/lib/python3.9/site-packages/s1reader/s1_reader.py:486: UserWarning: None of provided bursts IDs found
  warnings.warn("None of provided bursts IDs found")
```

