### PR TITLE
downloading orbit

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -7,3 +7,4 @@ dependencies:
   - gdal
   - isce3
   - shapely
+  - sentineleof

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 gdal
 #isce3    # since the conda-installed isce3 is not the most updated version, installing isce3 from stratch is recommended, to stay in sync with isce3 development.
 shapely
+sentineleof

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -3,6 +3,7 @@ import glob
 import os
 import warnings
 
+from eof.download import download_eofs
 
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
@@ -131,3 +132,12 @@ def get_orbit_file_from_dir(path: str, orbit_dir: str) -> str:
     orbit_path = get_orbit_file_from_list(path, orbit_file_list)
 
     return orbit_path
+
+def download_orbit_file(safe_path: str, save_dir: str='.'):
+    if not os.path.isdir(save_dir):
+        raise NotADirectoryError(f"{save_dir} not found")
+
+    downloaded_files = download_eofs(sentinel_file=safe_path,
+                                     save_dir=save_dir)
+
+    return downloaded_files


### PR DESCRIPTION
This PR puts the thinnest of wrappers on @scottstanie [sentineleof module](https://github.com/scottstanie/sentineleof) to download EOF modules from ESA or ASF.

The following script demonstrates usage:
```python
from s1reader.s1_orbit import download_orbit_file

safe_no_ext = 'S1A_IW_SLC__1SDV_20200511T135117_20200511T135144_032518_03C421_7768.'

# test both zip file and SAFE directory
for ext in ['zip', 'SAFE']:
    downloaded = download_orbit_file(f'{safe_no_ext}{ext}')
    print(downloaded)
```