### PR TITLE
Add orbit download functionality

### DIFF
--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -5,19 +5,14 @@ import os
 import requests
 import warnings
 
+from xml.etree import ElementTree
+
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
 
-# Required for orbit download
-scihub_url = 'https://scihub.copernicus.eu/gnss/odata/v1/Products'
-# Namespaces of the XML file returned by the S1 query. Will they change it?
-w3_url = '{http://www.w3.org/2005/Atom}'
-m_url = '{http://schemas.microsoft.com/ado/2007/08/dataservices/metadata}'
-d_url = '{http://schemas.microsoft.com/ado/2007/08/dataservices}'
 # Scihub guest credential
 scihub_user = 'gnssguest'
 scihub_password = 'gnssguest'
-
 
 def check_internet_connection():
     '''
@@ -78,6 +73,12 @@ def get_orbit_dict(sensor_id, start_time, end_time, orbit_type):
     orbit_dict: dict
         Python dictionary with [orbit_name, orbit_type, download_url]
     '''
+    # Required for orbit download
+    scihub_url = 'https://scihub.copernicus.eu/gnss/odata/v1/Products'
+    # Namespaces of the XML file returned by the S1 query. Will they change it?
+    m_url = '{http://schemas.microsoft.com/ado/2007/08/dataservices/metadata}'
+    d_url = '{http://schemas.microsoft.com/ado/2007/08/dataservices}'
+
     # Check if correct orbit_type
     if orbit_type not in ['AUX_POEORB', 'AUX_RESORB']:
         err_msg = f'{orbit_type} not a valid orbit type'

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -197,19 +197,8 @@ def get_file_name_tokens(zip_path: str) -> [str, list[datetime.datetime]]:
     t_swath_start_stop: list[datetime.datetime]
         Swath start/stop times
     '''
-    file_name_tokens = os.path.basename(zip_path).split('_')
-
-    # extract and check platform ID
-    platform_id = file_name_tokens[0]
-    if platform_id not in ['S1A', 'S1B']:
-        err_str = f'{platform_id} not S1A nor S1B'
-        ValueError(err_str)
-
-    # extract start/stop time as a list[datetime.datetime]: [t_start, t_stop]
-    t_swath_start_stop = [datetime.datetime.strptime(t, FMT)
-                          for t in file_name_tokens[5:7]]
-
-    return platform_id, t_swath_start_stop
+    platform_id, _, start_time, end_time, _ = parse_safe_filename(zip_path)
+    return platform_id,[start_time, end_time]
 
 
 # lambda to check if file exists if desired sat_id in basename

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -38,11 +38,13 @@ def download_orbit(safe_file, orbit_dir):
     orbit_dict = get_orbit_dict(sensor_id, start_time,
                                 end_time, 'AUX_POEORB')
     # If orbit dict is empty, find restituted orbits
-    if orbit_dict == None:
+    if orbit_dict is None:
         orbit_dict = get_orbit_dict(sensor_id, start_time,
                                     end_time, 'AUX_RESORB')
     # Download orbit file
-    download_orbit_file(orbit_dir, orbit_dict['orbit_url'])
+    filename = os.path.join(orbit_dir, orbit_dict["orbit_name"])
+    if not os.path.exists(filename):
+       download_orbit_file(orbit_dir, orbit_dict['orbit_url'])
 
 
 def check_internet_connection():
@@ -60,11 +62,12 @@ def parse_safe_filename(safe_filename):
     '''
     Extract info from S1-A/B SAFE filename
     SAFE filename structure: S1A_IW_SLC__1SDV_20150224T114043_20150224T114111_004764_005E86_AD02.SAFE
-    Parameters:
+    Parameters
     -----------
     safe_filename: string
        Path to S1-A/B SAFE file
-    Returns:
+
+    Returns
     -------
     List of [sensor_id, mode_id, start_datetime,
                 end_datetime, abs_orbit_num]
@@ -74,7 +77,7 @@ def parse_safe_filename(safe_filename):
        stop_datetime: acquisition stop datetime
        abs_orbit_num: absolute orbit number
 
-    Examples:
+    Examples
     ---------
     parse_safe_filename('S1A_IW_SLC__1SDV_20150224T114043_20150224T114111_004764_005E86_AD02.SAFE')
     returns
@@ -97,7 +100,7 @@ def parse_safe_filename(safe_filename):
 def get_orbit_dict(sensor_id, start_time, end_time, orbit_type):
     '''
     Query Copernicus GNSS API to find latest orbit file
-    Parameters:
+    Parameters
     ----------
     sensor_id: str
         Sentinel satellite identifier ('A' or 'B')
@@ -107,7 +110,9 @@ def get_orbit_dict(sensor_id, start_time, end_time, orbit_type):
         Sentinel end acquisition time
     orbit_type: str
         Type of orbit to download (AUX_POEORB: precise, AUX_RESORB: restituted)
-    Returns:
+
+    Returns
+    -------
     orbit_dict: dict
         Python dictionary with [orbit_name, orbit_type, download_url]
     '''
@@ -156,7 +161,7 @@ def get_orbit_dict(sensor_id, start_time, end_time, orbit_type):
 def download_orbit_file(output_folder, orbit_url):
     '''
     Download S1-A/B orbits
-    Parameters:
+    Parameters
     ----------
     output_folder: str
         Path to directory where to store orbits
@@ -177,15 +182,15 @@ def download_orbit_file(output_folder, orbit_url):
 def get_file_name_tokens(zip_path: str) -> [str, list[datetime.datetime]]:
     '''Extract swath platform ID and start/stop times from SAFE zip file path.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     zip_path: list[str]
         List containing orbit path strings. Orbit files required to adhere to
         naming convention found here:
         https://s1qc.asf.alaska.edu/aux_poeorb/
 
-    Returns:
-    --------
+    Returns
+    -------
     platform_id: ('S1A', 'S1B')
     orbit_path : str
         Path the orbit file.


### PR DESCRIPTION
This PR adds to the reader the capability of downloading orbits (precise or restituted) given a SAFE file.
It requires `requests` as a dependency and orbits are downloaded from SciHub using guest credentials.

The code was originally included in the Geocoded CSLC burst stack processor but it is more appropriate to attribute orbit download to the s1-reader