### PR TITLE
add `version.py` as the single-source version history

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = s1reader
-version = 0.1.0
+version = attr: s1reader.__version__
 description = A Sentinel1 metadata reader
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/s1reader/__init__.py
+++ b/src/s1reader/__init__.py
@@ -1,3 +1,6 @@
+# version info
+from .version import release_version as __version__
+
 # top-level functions to be easily used
 from .s1_burst_slc import Sentinel1BurstSlc
 from .s1_reader import load_bursts

--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -1,0 +1,17 @@
+# release history
+
+import collections
+
+
+# release history
+Tag = collections.namedtuple('Tag', 'version date')
+release_history = (
+    Tag('0.1.0', '2022-06-07'),
+)
+
+# latest release version number and date
+release_version = release_history[0].version
+release_date = release_history[0].date
+
+# variable
+__version__ = release_version


### PR DESCRIPTION
Similar to https://github.com/opera-adt/COMPASS/pull/36, so that we only need to update version.py while cutting for a new release.