### PR TITLE
setup: access version w/o __init__ to avoid circular imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-include_package_data = true
+include_package_data = True
 python_requires = >=3.9
 install_requires =
     setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = s1reader
-version = attr: s1reader.__version__
-description = A Sentinel1 metadata reader
+version = attr: s1reader.version.release_version
+description = A Sentinel-1 reader for ISCE3
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/opera-adt/s1-reader
@@ -16,10 +16,12 @@ classifiers =
 package_dir =
     = src
 packages = find:
+include_package_data = true
 python_requires = >=3.9
-include_package_data = True
+install_requires =
+    setuptools
+    importlib_resources
 
 [options.packages.find]
 where = src
-[options.package_data]
 

--- a/src/s1reader/__init__.py
+++ b/src/s1reader/__init__.py
@@ -1,7 +1,7 @@
 # version info
-from .version import release_version as __version__
+from s1reader.version import release_version as __version__
 
 # top-level functions to be easily used
-from .s1_burst_slc import Sentinel1BurstSlc
-from .s1_reader import load_bursts
-from .s1_orbit import get_orbit_file_from_dir
+from s1reader.s1_burst_slc import Sentinel1BurstSlc
+from s1reader.s1_reader import load_bursts
+from s1reader.s1_orbit import get_orbit_file_from_dir

--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -14,5 +14,3 @@ release_history = (
 release_version = release_history[0].version
 release_date = release_history[0].date
 
-# variable
-__version__ = release_version


### PR DESCRIPTION
This PR fixes the pip install error introduced in #54. The detailed changes are as below:

+ `setup.cfg`: setup the version number via `version.release_version`, instead of going through `__init__`, to avoid the circular imports that causes the pip install "ModuleNotFoundError"
+ `setup.cfg`: add `install_requires` and remove `[opptions.package_data]` to be consistent with compass
+ `__init__.py`: use absolute module import, to be consistent with the good style from pyresample module
+ `version.py`: remove the duplicated `__version__` variable.