### PR TITLE
s1_reader: refactor track_burst_num + optional noise + add file_id

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -148,6 +148,7 @@ class Sentinel1BurstSlc:
     polarization: str # {VV, VH, HH, HV}
     burst_id: str # t{track_number}_{burst_index}_iw{1,2,3}
     platform_id: str # S1{A,B}
+    file_id: str # SAFE file name
     center: tuple # {center lon, center lat} in degrees
     border: list # list of lon, lat coordinate tuples (in degrees) representing burst border
     orbit: isce3.core.Orbit
@@ -620,5 +621,5 @@ class Sentinel1BurstSlc:
     @property
     def swath_name(self):
         '''Swath name in iw1, iw2, iw3.'''
-        return self.burst_id.split('_')[1]
+        return self.burst_id.split('_')[2]
 


### PR DESCRIPTION
+ `s1_reader`: add `get_track_burst_num()` to read the start/stop burst number info from ESA. This returns a dict, which could simplify the logic of converting the local burst num to the global version.

+ `s1_reader.burst_from_xml()`: skip reading the noise annotation files if not necessary, to support downloaded metadata using `asfsmd` without noise/slc data

+ `s1_burst_slc.Sentinel1BurstSlc`: add new field "file_id"

+ `s1_burst_slc.Sentinel1BurstSlc`: adjust the `swath_name()` from the previous version of burst IDs to the latest ESA's version (#47).