### PR TITLE
s1_reader.py:zero pad burst_num in `.burst_id`

### DIFF
--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -632,7 +632,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                           last_valid_samples[last_line])
 
 
-        burst_id = f't{track_number:03d}_{burst_num}_{swath_name.lower()}'
+        burst_id = f't{track_number:03d}_{burst_num:06d}_{swath_name.lower()}'
 
 
         # Extract burst-wise information for Calibration, Noise, and EAP correction


### PR DESCRIPTION
The current format doesnt matche the assumed format of the burst database.

https://github.com/opera-adt/burst_db/blob/main/build_database.py#L164

This will always set the burst_num to be 6 digits long.


An alternative to this fix could be 
1. change the burst database, or
2. Start pulling organization-wide utility functions into a separate, shared repository so that the implementations dont diverge (like `get_point_epsg`)