### PR TITLE
make the noise/calibration/orbit reading optional

### DIFF
--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -493,7 +493,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
             calibration_annotation =\
                 CalibrationAnnotation.from_et(tree_cads,
                                               calibration_annotation_path)
-    except FileNotFoundError:
+    except (FileNotFoundError, KeyError):
         calibration_annotation = None
 
     # load the Noise annotation
@@ -503,7 +503,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
             tree_nads = ET.parse(f_nads)
             noise_annotation = NoiseAnnotation.from_et(tree_nads, ipf_version,
                                                        noise_annotation_path)
-    except FileNotFoundError:
+    except (FileNotFoundError, KeyError):
         noise_annotation = None
 
     # load AUX_CAL annotation


### PR DESCRIPTION
While testing the burst database, I was downloading just the annotation files using https://github.com/avalentino/asfsmd . Since a lot of s1reader's functionality/usefulness comes from just the manifest and annotation files, it would be nice to allow optional loading without an orbit file or noise/calibration files.

The no-orbit case could be eventually changed by #41 to use the SAFE orbit. For the noise/calibration, it seems like since we already allow loading without the actual images here, we should then be able to skip the calibration on the image
https://github.com/opera-adt/s1-reader/blob/4000bc7a31d79e740212ab31495ca28ad0e2d426/src/s1reader/s1_reader.py#L844-L847