### PR TITLE
add a --bbox option to s1_info for frame bounds

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -417,18 +417,22 @@ class Sentinel1BurstSlc:
             err_str = f'Following step size(s) <=0: {step_errs}'
             raise ValueError(err_str)
 
+        # container to store names of axis vectors that are invalid: i.e. size 0
+        vec_errs = []
+
+        # compute range vector
         n_range = np.ceil(self.width * self.range_pixel_spacing / range_step).astype(int)
         range_vec = self.starting_range + np.arange(0, n_range) * range_step
+        if range_vec.size == 0:
+            vec_errs.append('range')
 
+        # compute azimuth vector
         n_az = np.ceil(self.length * self.azimuth_time_interval / az_step).astype(int)
         rdrgrid = self.as_isce3_radargrid()
         az_vec = rdrgrid.sensing_start + np.arange(0, n_az) * az_step
-
-        vec_errs = []
-        if not range_vec:
-            vec_errs.append('range')
-        if not az_vec:
+        if az_vec.size == 0:
             vec_errs.append('azimuth')
+
         if vec_errs:
             vec_errs = ', '.join(vec_errs)
             err_str = f'Cannot build aranges from following step(s): {vec_errs}'

--- a/src/s1reader/s1_info.py
+++ b/src/s1reader/s1_info.py
@@ -1,8 +1,6 @@
 """Extract the burst ID information from a Sentinel-1 SLC product."""
 import argparse
-import shutil
 import sys
-import tempfile
 import warnings
 import zipfile
 from itertools import chain

--- a/src/s1reader/s1_info.py
+++ b/src/s1reader/s1_info.py
@@ -119,7 +119,17 @@ def _bounds_from_preview(safe_path: Union[Path, str]) -> List[float]:
 def _bounds_from_bursts(safe_path: Union[Path, str]) -> List[float]:
     """Get the bounding box of the frame from the union of all burst bounds."""
     # Get all the bursts from subswath 1, 2, 3
-    bursts = get_bursts(safe_path)
+    bursts = None
+    for pol in ["vv", "hh", "hv", "vh"]:
+        try:
+            bursts = get_bursts(safe_path, pol=pol)
+            break
+        except ValueError:
+            # This is raised if the product doesn't have the specified polarization 
+            continue
+    if bursts is None:
+        raise ValueError("Could not load any polarizations in {safe_path}.")
+
     # Convert the border (list of polygons) into a MultiPolygon
     all_borders = [shapely.geometry.MultiPolygon(b.border) for b in bursts]
     # Perform a union to get one shape for the entire frame

--- a/src/s1reader/s1_info.py
+++ b/src/s1reader/s1_info.py
@@ -52,7 +52,70 @@ def _plot_bursts(safe_path: Union[Path, str], output_dir="burst_maps") -> None:
     plot_bursts.burst_map(safe_path, orbit_dir, xs, ys, epsg, output_filename)
 
 
-def _get_frame_bounds(safe_path: Union[Path, str]) -> List[float]:
+def get_frame_bounds(safe_path: Union[Path, str]) -> List[float]:
+    try:
+        return _bounds_from_preview(safe_path)
+    except Exception as e:
+        warnings.warn(f"Could not get bounds for {safe_path}: {e}")
+    return _bounds_from_bursts(safe_path)
+
+
+def _bounds_from_preview(safe_path: Union[Path, str]) -> List[float]:
+    import lxml.etree as ET
+    import tempfile
+    import zipfile
+
+    # looking for:
+    # S1A_IW_SLC__1SDV_20221005T125539_20221005T125606_045307_056AA5_CB45.SAFE/preview/map-overlay.kml
+    if _is_safe_dir(safe_path):
+        overlay_path = Path(safe_path) / "preview" / "map-overlay.kml"
+    else:
+        # The name of the unzipped .SAFE directory (with .zip stripped)
+        tmp_dir = tempfile.TemporaryDirectory()
+        with zipfile.ZipFile(safe_path, "r") as zip_ref:
+            zname = [
+                zi
+                for zi in zip_ref.infolist()
+                if "preview/map-overlay.kml" in zi.filename
+            ][0]
+            map_overlay_kml = zip_ref.extract(zname, path=tmp_dir)
+
+    # Check that they have all the necessary kmls
+    if not map_overlay_kml.exists():
+        raise ValueError(f"{map_overlay_kml} does not exist to get extent.")
+    root = ET.parse(overlay_path).getroot()
+
+    # point_str looks like:
+    # <coordinates>-102.552971,31.482372 -105.191353,31.887299...
+    point_str = list(elem.text for elem in root.iter("coordinates"))[0]
+    coords = [p.split(",") for p in point_str.split()]
+    lons, lats = zip(*[(float(lon), float(lat)) for lon, lat in coords])
+    return (min(lons), min(lats), max(lons), max(lats))
+
+
+# [1]+ wget https://datapool.asf.alaska.edu/SLC/SA/S1A_IW_SLC__1SDV_20221122T125539_20221122T125606_046007_058187_36E8.zip &	(wd: ~/dev/texas/mentone-earthquake-2022-11-16/data)
+#   1 <?xml version="1.0" encoding="UTF-8"?>
+#   2 <kml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sent    inel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="    http://www.google.com/kml/ext/2.2">
+#   3   <Document>
+#   4     <name>Sentinel-1 Map Overlay</name>
+#   5     <Folder>
+#   6       <name>Sentinel-1 Scene Overlay</name>
+#   7       <GroundOverlay>
+#   8         <name>Sentinel-1 Image Overlay</name>
+#   9         <Icon>
+#  10           <href>quick-look.png</href>
+#  11         </Icon>
+#  12         <gx:LatLonQuad>
+#  13           <coordinates>-102.622429,31.201340 -105.269714,31.609007 -104.947639,33.238331 -102.250290,32.832924</coordinates>
+#  14         </gx:LatLonQuad>
+#  15       </GroundOverlay>
+#  16     </Folder>
+#  17   </Document>
+#  18 </kml>
+# ~
+
+
+def _bounds_from_bursts(safe_path: Union[Path, str]) -> List[float]:
     """Get the bounding box of the frame from the union of all burst bounds.
 
     bounding box format is [lonmin, latmin, lonmax, latmax]
@@ -164,7 +227,7 @@ def main():
             _plot_bursts(path)
             continue
         elif args.bbox:
-            msg = f"{path}: {_get_frame_bounds(path)}"
+            msg = f"{path}: {get_frame_bounds(path)}"
             print(msg)
             continue
 


### PR DESCRIPTION
Adds an option to get a quick bounding box for a frame. It'll use the preview/kml if it's there (for instance, in a full .zip file or SAFE with all files in it), otherwise it'll union all the burst `.bounds` (which is slower).

```
$ s1_info --bbox data/
Found 3 Sentinel-1 SLC products.
data/S1A_IW_SLC__1SDV_20221005T125539_20221005T125606_045307_056AA5_CB45.zip: [-105.269714, 31.20134, -102.25029, 33.238331]
data/S1A_IW_SLC__1SDV_20221010T010026_20221010T010052_045373_056CCC_4236.zip: [-106.049408, 30.349874, -103.073921, 32.378967]
data/S1A_IW_SLC__1SDV_20221017T125539_20221017T125606_045482_057043_39B5.zip: [-105.270958, 31.201355, -102.251465, 33.238483]
```


I wanted to add this for quick processing of a frame to know what area of a DEM to make:

```
$ s1_info --bbox data/S1A_IW_SLC__1SDV_20221005T125539_20221005T125606_045307_056AA5_CB45.zip | cut -d':' -f2 | tr -d ',[]' | xargs  sardem --data cop --bbox
Found 1 Sentinel-1 SLC products.
[11/22 09:52:33] [INFO dem.py] Bounds: -105.269714 31.20134 -102.25029 33.238331
[11/22 09:52:34] [INFO cop_dem.py] Creating elevation.dem
...
```


Other small change was to print the message `Found N Sentinel-1 SLC products.` to sys.stderr (like a logging message) so that you can output the bounds to a text file with a bash redirect without getting that message:

```
$ s1_info --bbox data/ > file_bounds.txt
Found 9 Sentinel-1 SLC products.
$ head file_bounds.txt
data/S1A_IW_SLC__1SDV_20221005T125539_20221005T125606_045307_056AA5_CB45.zip: [-105.269714, 31.20134, -102.25029, 33.238331]
data/S1A_IW_SLC__1SDV_20221010T010026_20221010T010052_045373_056CCC_4236.zip: [-106.049408, 30.349874, -103.073921, 32.378967]
data/S1A_IW_SLC__1SDV_20221017T125539_20221017T125606_045482_057043_39B5.zip: [-105.270958, 31.201355, -102.251465, 33.238483]
data/S1A_IW_SLC__1SDV_20221022T010025_20221022T010052_045548_0571F9_CD47.zip: [-106.049927, 30.349646, -103.07428, 32.378899]
data/S1A_IW_SLC__1SDV_20221029T125539_20221029T125606_045657_0575B4_5A19.zip: [-105.271835, 31.20146, -102.252258, 33.238682]
data/S1A_IW_SLC__1SDV_20221103T010025_20221103T010052_045723_0577DF_3D7C.zip: [-106.050217, 30.34918, -103.074463, 32.378494]
data/S1A_IW_SLC__1SDV_20221110T125538_20221110T125605_045832_057B9A_2798.zip: [-105.269913, 31.201473, -102.250328, 33.238564]
data/S1A_IW_SLC__1SDV_20221115T010025_20221115T010052_045898_057DD0_C9C8.zip: [-106.051247, 30.35001, -103.075516, 32.379051]
data/S1A_IW_SLC__1SDV_20221122T125539_20221122T125606_046007_058187_36E8.zip: [-105.272537, 31.201172, -102.252945, 33.238258]
```