### PR TITLE
bugfix in Sentinel1BurstSlc.swath_name()

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -668,7 +668,7 @@ class Sentinel1BurstSlc:
     @property
     def swath_name(self):
         '''Swath name in iw1, iw2, iw3.'''
-        return self.burst_id.swath_name
+        return self.burst_id.subswath.lower()
 
     @property
     def thermal_noise_lut(self):


### PR DESCRIPTION
Fix a bug in `s1_burst_slc.Sentinel1BurstSlc.swath_name()` introduced in #77. This fix is required to run https://github.com/opera-adt/opera-notebooks/pull/1.