### PR TITLE
s1_reader: fix safe_path for directories

### DIFF
--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -876,10 +876,7 @@ def _burst_from_safe_dir(safe_dir_path: str, id_str: str, orbit_path: str, flag_
 
     # find tiff file if measurement directory found
     if os.path.isdir(f'{safe_dir_path}/measurement'):
-        measurement_list = os.listdir(f'{safe_dir_path}/measurement')
-        f_tiff = [f for f in measurement_list
-                  if 'measurement' in f and id_str in f and 'tiff' in f]
-        f_tiff = f'{safe_dir_path}/measurement/{f_tiff[0]}' if f_tiff else ''
+        f_tiff = glob.glob(f'{safe_dir_path}/measurement/*{id_str}*tiff') or ''
     else:
         msg = f'measurement directory NOT found in {safe_dir_path}'
         msg += ', continue with metadata only.'

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -876,7 +876,8 @@ def _burst_from_safe_dir(safe_dir_path: str, id_str: str, orbit_path: str, flag_
 
     # find tiff file if measurement directory found
     if os.path.isdir(f'{safe_dir_path}/measurement'):
-        f_tiff = glob.glob(f'{safe_dir_path}/measurement/*{id_str}*tiff') or ''
+        f_tiff = glob.glob(f'{safe_dir_path}/measurement/*{id_str}*tiff')
+        f_tiff = f_tiff[0] if f_tiff else ''
     else:
         msg = f'measurement directory NOT found in {safe_dir_path}'
         msg += ', continue with metadata only.'


### PR DESCRIPTION
_burst_from_safe_dir used os.listdir, which does not have "measurement" in the returned names like the zip file list does

this fixes #90


Before:

```
In [15]: b1 = s1reader.load_bursts("./S1A_IW_SLC__1SDV_20210410T140757_20210410T140824_037389_046804_70EA.SAFE", "./S1A_OPER_AUX_POEORB_OPOD_20210430T121835_V20210409T225942_20210411T005942.EOF", 1)[0]

In [16]: b1.tiff_path
Out[16]: ''
```

after:

```

In [49]: b1 = s1reader.load_bursts("./S1A_IW_SLC__1SDV_20210410T140757_20210410T140824_037389_046804_70EA.SAFE", "./S1A_OPER_AUX_POEORB_OPOD_20210430T121835_V20210409T225942_20210411T005942.EOF", 1)[0]

In [50]: b1.tiff_path
Out[50]: './S1A_IW_SLC__1SDV_20210410T140757_20210410T140824_037389_046804_70EA.SAFE/measurement/s1a-iw1-slc-vv-20210410t140759-20210410t140824-037389-046804-004.tiff'

```