### PR TITLE
allow az_step/rg_step arguments to `as_isce3_radargrid`

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -282,26 +282,24 @@ class Sentinel1BurstSlc:
             RadarGridParameters constructed from class members.
         '''
 
+        width, length = self.shape
         if az_step is None:
             az_step = self.azimuth_time_interval
-            length = self.shape[0]
         else:
-            length_in_seconds = length / self.azimuth_time_interval
             if az_step < 0:
                 raise ValueError("az_step cannot be negative")
-            if 1 / az_step > length_in_seconds:
+            length_in_seconds = length * self.azimuth_time_interval
+            if az_step > length_in_seconds:
                 raise ValueError("az_step cannot be larger than radar grid")
-            length = (length / self.azimuth_time_interval) // az_step
-
+            length = length_in_seconds // az_step
 
         if rg_step is None:
             rg_step = self.range_pixel_spacing
-            width = self.shape[1]
         else:
-            width_in_meters = width * self.range_pixel_spacing
             if rg_step < 0:
                 raise ValueError("rg_step cannot be negative")
-            if rg_step > width * width_in_meters:
+            width_in_meters = width * self.range_pixel_spacing
+            if rg_step > width_in_meters:
                 raise ValueError("rg_step cannot be larger than radar grid")
             width = (width_in_meters) // rg_step
 

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -291,7 +291,7 @@ class Sentinel1BurstSlc:
             length_in_seconds = length * self.azimuth_time_interval
             if az_step > length_in_seconds:
                 raise ValueError("az_step cannot be larger than radar grid")
-            length = length_in_seconds // az_step
+            length = int(length_in_seconds / az_step)
 
         if rg_step is None:
             rg_step = self.range_pixel_spacing
@@ -301,7 +301,7 @@ class Sentinel1BurstSlc:
             width_in_meters = width * self.range_pixel_spacing
             if rg_step > width_in_meters:
                 raise ValueError("rg_step cannot be larger than radar grid")
-            width = (width_in_meters) // rg_step
+            width = int(width_in_meters / rg_step)
 
         prf = 1 / az_step
 

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -264,8 +264,16 @@ class Sentinel1BurstSlc:
     def __repr__(self):
         return f"{self.__class__.__name__}(burst_id={self.burst_id})"
 
-    def as_isce3_radargrid(self, az_step: Optional[float] = None, rg_step: Optional[float] = None):
+    def as_isce3_radargrid(self,
+                           az_step: Optional[float] = None,
+                           rg_step: Optional[float] = None):
         '''Init and return isce3.product.RadarGridParameters.
+
+        The `az_step` and `rg_step` parameters are used to construct a
+        decimated grid. If not specified, the grid will be at the full radar
+        resolution.
+        Note that increasing the range/azimuth step size does not change the sensing
+        start of the grid, as the grid is decimated rather than multilooked.
 
         Parameters
         ----------

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 import datetime
 import tempfile
+from typing import Optional
 import warnings
 from packaging import version
 
@@ -263,16 +264,30 @@ class Sentinel1BurstSlc:
     def __repr__(self):
         return f"{self.__class__.__name__}(burst_id={self.burst_id})"
 
-    def as_isce3_radargrid(self):
+    def as_isce3_radargrid(self, az_step: Optional[float] = None, rg_step: Optional[float] = None):
         '''Init and return isce3.product.RadarGridParameters.
 
-        Returns:
-        --------
+        Parameters
+        ----------
+        az_step : float, optional
+            Azimuth step size in seconds. If not provided, the azimuth step
+            size is set to the azimuth time interval.
+        rg_step : float, optional
+            Range step size in meters. If not provided, the range step size
+            is set to the range pixel spacing.
+
+        Returns
+        -------
         _ : RadarGridParameters
             RadarGridParameters constructed from class members.
         '''
 
+        if az_step is None:
+            az_step = self.azimuth_time_interval
         prf = 1 / self.azimuth_time_interval
+
+        if rg_step is None:
+            rg_step = self.range_pixel_spacing
 
         length, width = self.shape
 
@@ -286,7 +301,7 @@ class Sentinel1BurstSlc:
                                                  self.wavelength,
                                                  prf,
                                                  self.starting_range,
-                                                 self.range_pixel_spacing,
+                                                 rg_step,
                                                  isce3.core.LookSide.Right,
                                                  length,
                                                  width,

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -284,7 +284,7 @@ class Sentinel1BurstSlc:
 
         if az_step is None:
             az_step = self.azimuth_time_interval
-        prf = 1 / self.azimuth_time_interval
+        prf = 1 / az_step
 
         if rg_step is None:
             rg_step = self.range_pixel_spacing

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -282,7 +282,7 @@ class Sentinel1BurstSlc:
             RadarGridParameters constructed from class members.
         '''
 
-        width, length = self.shape
+        length, width = self.shape
         if az_step is None:
             az_step = self.azimuth_time_interval
         else:

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -284,12 +284,28 @@ class Sentinel1BurstSlc:
 
         if az_step is None:
             az_step = self.azimuth_time_interval
-        prf = 1 / az_step
+            length = self.shape[0]
+        else:
+            length_in_seconds = length / self.azimuth_time_interval
+            if az_step < 0:
+                raise ValueError("az_step cannot be negative")
+            if 1 / az_step > length_in_seconds:
+                raise ValueError("az_step cannot be larger than radar grid")
+            length = (length / self.azimuth_time_interval) // az_step
+
 
         if rg_step is None:
             rg_step = self.range_pixel_spacing
+            width = self.shape[1]
+        else:
+            width_in_meters = width * self.range_pixel_spacing
+            if rg_step < 0:
+                raise ValueError("rg_step cannot be negative")
+            if rg_step > width * width_in_meters:
+                raise ValueError("rg_step cannot be larger than radar grid")
+            width = (width_in_meters) // rg_step
 
-        length, width = self.shape
+        prf = 1 / az_step
 
         time_delta = datetime.timedelta(days=2)
         ref_epoch = isce3.core.DateTime(self.sensing_start - time_delta)


### PR DESCRIPTION
This allows a more coarse radar grid, as needed by some lookup tables such as the SET correction.

(this is mostly to help with cross-repo code duplication https://github.com/opera-adt/COMPASS/pull/91/files#diff-69dd9219c200228243e2fc9517100d1c8c2887874819ba403614548352b14b29R277-R292 )