### PR TITLE
s1_orbit: return S1A/S1B when parsing filename

### DIFF
--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -110,7 +110,7 @@ def get_file_name_tokens(zip_path: str) -> [str, list[datetime.datetime]]:
     Parameters
     ----------
     zip_path: list[str]
-        List containing orbit path strings. 
+        List containing orbit path strings.
         Orbit files required to adhere to naming convention found here:
         https://sentinels.copernicus.eu/documents/247904/351187/Copernicus_Sentinels_POD_Service_File_Format_Specification
 

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -47,7 +47,7 @@ def download_orbit(safe_file: str, orbit_dir: str):
         orbit_dict = get_orbit_dict(mission_id, start_time,
                                     end_time, 'AUX_RESORB')
     # Download orbit file
-    orbit_file = os.path.join(orbit_dir, orbit_dict["orbit_name"] + '.EOF')
+    orbit_file = os.path.join(orbit_dir, f"{orbit_dict['orbit_name']}.EOF")
     if not os.path.exists(orbit_file):
         download_orbit_file(orbit_dir, orbit_dict['orbit_url'])
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -6,11 +6,31 @@ from shapely.geometry import Point
 
 from s1reader.s1_orbit import get_orbit_file_from_dir
 
+
 def test_get_orbit_file(test_paths):
     orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
 
     expected_orbit_path = f'{test_paths.orbit_dir}/{test_paths.orbit_file}'
     assert orbit_file == expected_orbit_path
+
+
+def test_get_orbit_file_multi_mission(tmp_path):
+    orbit_a = tmp_path / "S1A_OPER_AUX_POEORB_OPOD_20210314T131617_V20191007T225942_20191009T005942.EOF"
+    orbit_a.write_text("")
+    orbit_b = tmp_path / "S1B_OPER_AUX_POEORB_OPOD_20210304T232500_V20191007T225942_20191009T005942.EOF"
+    orbit_b.write_text("")
+
+    zip_path = tmp_path / "zips"
+    zip_path.mkdir()
+    zip_a = zip_path / "S1A_IW_SLC__1SDV_20191008T005936_20191008T010003_018377_0229E5_909C.zip"
+    zip_a.write_text("")
+    zip_b = zip_path / "S1B_IW_SLC__1SDV_20191008T005936_20191008T010003_018377_0229E5_909C.zip"
+    zip_b.write_text("")
+
+    # Test S1A zip file
+    assert get_orbit_file_from_dir(zip_a, orbit_dir=tmp_path) == str(orbit_a)
+    assert get_orbit_file_from_dir(zip_b, orbit_dir=tmp_path) == str(orbit_b)
+
 
 def test_orbit_datetime(bursts):
     # pad in seconds used in orbit_reader


### PR DESCRIPTION
This fixes #103 to get the right orbit file.

Currently we are returning "A" or "B" as a "sensor_id", then searching if the orbit file has that identifier (the single letter, which all orbit files have).

This 1. changes the parser to return the full S1A/S1B, 2. calls it the "mission_id" to match the language in the product spec https://sentinels.copernicus.eu/documents/247904/351187/Copernicus_Sentinels_POD_Service_File_Format_Specification

3. does further simplficication and cleanup of logic to make pylance/flake8 errors go away

The movement of function locations is to group similar functions together (`parse_safe_filename` and `get_file_name_tokens` were >100 lines apart before)