### PR TITLE
use radargrid step parameters to simplify `_steps_to_vecs`

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -767,7 +767,7 @@ class Sentinel1BurstSlc:
         os.makedirs(path_scratch, exist_ok=True)
 
         # define the radar grid to calculate az fm mismatch rate
-        correction_radargrid = self.as_isce3_radargrid(az_step=az_step, range_step=range_step)
+        correction_radargrid = self.as_isce3_radargrid(az_step=az_step, rg_step=range_step)
 
         # Run topo on scratch directory
         if not os.path.isfile(path_dem):


### PR DESCRIPTION
Now that the function `self.as_isce3_radargrid` has parameters for step sizes, we dont need to redo the logic to compute the coordinates.

This should fix #105 where the differing logic causes different coordinates.

It also allows us to remove redundant error checking that happens in the `as_isce3_radaragrid` function