### PR TITLE
s1_burst_id: fix logic for track 174 anx crossing

### DIFF
--- a/src/s1reader/s1_burst_id.py
+++ b/src/s1reader/s1_burst_id.py
@@ -80,7 +80,9 @@ class S1BurstId:
         start_iw1_to_mid_iw2 = burst_times[0] + burst_times[1] / 2
         mid_iw2 = start_iw1 + datetime.timedelta(seconds=start_iw1_to_mid_iw2)
 
-        has_anx_crossing = end_track == (start_track + 1) % 175
+        has_anx_crossing = (end_track == start_track + 1) or (
+            end_track == 1 and start_track == 175
+        )
 
         time_since_anx_iw1 = (start_iw1 - ascending_node_dt).total_seconds()
         time_since_anx = (mid_iw2 - ascending_node_dt).total_seconds()
@@ -113,7 +115,7 @@ class S1BurstId:
         Parameters
         ----------
         burst_id_str : str
-            The burst ID string, e.g. "t123_456_iw1"
+            The burst ID string, e.g. "t123_00456_iw1"
 
         Returns
         -------

--- a/src/s1reader/s1_burst_id.py
+++ b/src/s1reader/s1_burst_id.py
@@ -115,7 +115,7 @@ class S1BurstId:
         Parameters
         ----------
         burst_id_str : str
-            The burst ID string, e.g. "t123_00456_iw1"
+            The burst ID string, e.g. "t123_000456_iw1"
 
         Returns
         -------


### PR DESCRIPTION
Fixes #114.

We should add a unit test for this granule that compares it to the `burstId` in the XML metadata (which is available since it's a 2023 acquisition):

```
$ grep burstId S1A_IW_SLC__1SDV_20230115T162143_20230115T162211_046796_059C50_1250.SAFE/annotation/s1a-iw1-slc-vv-20230115t162145-20230115t162210-046796-059c50-004.xml
        <burstId absolute="100514426">373734</burstId>
        <burstId absolute="100514427">373735</burstId>
        <burstId absolute="100514428">373736</burstId>
        <burstId absolute="100514429">373737</burstId>
        <burstId absolute="100514430">373738</burstId>
        <burstId absolute="100514431">373739</burstId>
        <burstId absolute="100514432">373740</burstId>
        <burstId absolute="100514433">373741</burstId>
        <burstId absolute="100514434">373742</burstId>
(mapping) staniewi:s1-reader$ grep relativeO S1A_IW_SLC__1SDV_20230115T162143_20230115T162211_046796_059C50_1250.SAFE/manifest.safe
            <safe:relativeOrbitNumber type="start">174</safe:relativeOrbitNumber>
            <safe:relativeOrbitNumber type="stop">175</safe:relativeOrbitNumber>
```

```
In [5]: s1reader.load_bursts( "./S1A_IW_SLC__1SDV_20230115T162143_20230115T162211_046796_059C50_1250.SAFE", None, 1)
measurement directory NOT found in ./S1A_IW_SLC__1SDV_20230115T162143_20230115T162211_046796_059C50_1250.SAFE, continue with metadata only.
Out[5]:
[
    Sentinel1BurstSlc(burst_id=t174_373734_iw1),
    Sentinel1BurstSlc(burst_id=t174_373735_iw1),
    Sentinel1BurstSlc(burst_id=t174_373736_iw1),
    Sentinel1BurstSlc(burst_id=t174_373737_iw1),
    Sentinel1BurstSlc(burst_id=t174_373738_iw1),
    Sentinel1BurstSlc(burst_id=t174_373739_iw1),
    Sentinel1BurstSlc(burst_id=t175_373740_iw1),
    Sentinel1BurstSlc(burst_id=t175_373741_iw1),
    Sentinel1BurstSlc(burst_id=t175_373742_iw1)
]
```