### PR TITLE
0.1.6 -> 0.1.7

### DIFF
--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -6,6 +6,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.1.7', '2023-05-09'),
     Tag('0.1.6', '2023-03-22'),
     Tag('0.1.5', '2022-12-21'),
     Tag('0.1.4', '2022-12-16'),


### PR DESCRIPTION
This PR is to update the version for `s1-reader` before cutting the release for upcoming SAS delivery.