### PR TITLE
Annotation class attrs

### DIFF
--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -94,7 +94,7 @@ class AnnotationBase:
     A virtual base class of the inheriting annotation class i.e. Product, Calibration, and Noise.
     Not intended for standalone use.
     '''
-    
+
     @staticmethod
     def _parse_scalar(xml_et: ET.ElementTree, path_field: str, str_type: str):
         '''A class method that parse the scalar value in AnnotationBase.xml_et
@@ -432,59 +432,60 @@ class ProductAnnotation(AnnotationBase):
             Parsed LADS from et_in
         '''
         antenna_pattern_azimuth_time = \
-            cls._parse_vectorlist(et_in, 
+            cls._parse_vectorlist(et_in,
                                   'antennaPattern/antennaPatternList',
                                   'azimuthTime',
                                   'datetime')
         antenna_pattern_slant_range_time = \
-            cls._parse_vectorlist(et_in, 
+            cls._parse_vectorlist(et_in,
                                   'antennaPattern/antennaPatternList',
                                   'slantRangeTime',
                                   'vector_float')
         antenna_pattern_elevation_angle = \
-            cls._parse_vectorlist(et_in, 
+            cls._parse_vectorlist(et_in,
                                   'antennaPattern/antennaPatternList',
                                   'elevationAngle',
                                   'vector_float')
         antenna_pattern_elevation_pattern = \
-            cls._parse_vectorlist(et_in, 
+            cls._parse_vectorlist(et_in,
                                   'antennaPattern/antennaPatternList',
                                   'elevationPattern',
                                   'vector_float')
 
         antenna_pattern_incidence_angle = \
-            cls._parse_vectorlist(et_in, 
+            cls._parse_vectorlist(et_in,
                                   'antennaPattern/antennaPatternList',
                                   'incidenceAngle',
                                   'vector_float')
 
         image_information_slant_range_time = \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'imageAnnotation/imageInformation/slantRangeTime',
                               'scalar_float')
         ascending_node_time = \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'imageAnnotation/imageInformation/ascendingNodeTime',
                               'datetime')
         number_of_samples = \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'imageAnnotation/imageInformation/numberOfSamples',
                               'scalar_int')
         number_of_samples = \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'imageAnnotation/imageInformation/numberOfSamples',
                               'scalar_int')
         range_sampling_rate = \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'generalAnnotation/productInformation/rangeSamplingRate',
                               'scalar_float')
         slant_range_time =  \
-            cls._parse_scalar(et_in, 
+            cls._parse_scalar(et_in,
                               'imageAnnotation/imageInformation/slantRangeTime',
                               'scalar_float')
 
         instrument_cfg_id = \
-            cls._parse_scalar('generalAnnotation/downlinkInformationList/downlinkInformation/'
+            cls._parse_scalar(et_in,
+                              'generalAnnotation/downlinkInformationList/downlinkInformation/'
                               'downlinkValues/instrumentConfigId',
                               'scalar_int')
 
@@ -785,7 +786,7 @@ class SwathMiscMetadata:
         return burst_misc_metadata
 
 
-def closest_block_to_azimuth_time(vector_azimuth_time: np.ndarray,
+def closest_block_to_azimuth_time(vector_azimuth_time: list,
                                   azimuth_time_burst: datetime.datetime) -> int:
     '''
     Find the id of the closest data block in annotation.
@@ -793,8 +794,10 @@ def closest_block_to_azimuth_time(vector_azimuth_time: np.ndarray,
 
     Parameters
     ----------
-    vector_azimuth_time : np.ndarray
-        numpy array azimuth time whose data type is datetime.datetime
+    vector_azimuth_time : list
+        list of azimuth times whose data type is datetime.datetime.
+        Comes from `_parse_vectorlist`
+
     azimuth_time_burst: datetime.datetime
         Azimuth time of the burst
 
@@ -805,7 +808,7 @@ def closest_block_to_azimuth_time(vector_azimuth_time: np.ndarray,
 
     '''
 
-    return np.argmin(np.abs(vector_azimuth_time - azimuth_time_burst))
+    return np.argmin(np.abs(np.array(vector_azimuth_time) - azimuth_time_burst))
 
 
 @dataclass

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -94,6 +94,7 @@ class AnnotationBase:
     A virtual base class of the inheriting annotation class i.e. Product, Calibration, and Noise.
     Not intended for standalone use.
     '''
+    
     @staticmethod
     def _parse_scalar(xml_et: ET.ElementTree, path_field: str, str_type: str):
         '''A class method that parse the scalar value in AnnotationBase.xml_et
@@ -133,7 +134,7 @@ class AnnotationBase:
 
         return val_out
 
-    @classmethod
+    @staticmethod
     def _parse_vectorlist(xml_et: ET.ElementTree,
                           name_vector_list: str,
                           name_vector: str,

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -94,8 +94,6 @@ class AnnotationBase:
     A virtual base class of the inheriting annotation class i.e. Product, Calibration, and Noise.
     Not intended for standalone use.
     '''
-    xml_et: ET
-
     @staticmethod
     def _parse_scalar(xml_et: ET.ElementTree, path_field: str, str_type: str):
         '''A class method that parse the scalar value in AnnotationBase.xml_et
@@ -223,40 +221,39 @@ class CalibrationAnnotation(AnnotationBase):
             Instance of CalibrationAnnotation initialized by the input parameter
         '''
 
-        cls.xml_et = et_in
-        cls.basename_annotation = \
-            os.path.basename(path_annotation)
+        basename_annotation = os.path.basename(path_annotation)
 
-        cls.list_azimuth_time = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'azimuthTime',
-                                  'datetime')
-        cls.list_line = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'line',
-                                  'scalar_int')
-        cls.list_pixel = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'pixel',
-                                  'vector_int')
-        cls.list_sigma_nought = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                'sigmaNought',
-                                'vector_float')
-        cls.list_beta_nought = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'betaNought',
-                                  'vector_float')
-        cls.list_gamma = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'gamma',
-                                  'vector_float')
-        cls.list_dn = \
-            cls._parse_vectorlist('calibrationVectorList',
-                                  'dn',
-                                  'vector_float')
+        list_azimuth_time = cls._parse_vectorlist(et_in,
+                                                  'calibrationVectorList',
+                                                  'azimuthTime',
+                                                  'datetime')
+        list_line = cls._parse_vectorlist(et_in,
+                                          'calibrationVectorList',
+                                          'line',
+                                          'scalar_int')
+        list_pixel = cls._parse_vectorlist(et_in,
+                                           'calibrationVectorList',
+                                           'pixel',
+                                           'vector_int')
+        list_sigma_nought = cls._parse_vectorlist(et_in,
+                                                  'calibrationVectorList',
+                                                  'sigmaNought',
+                                                  'vector_float')
+        list_beta_nought =  cls._parse_vectorlist(et_in,
+                                                  'calibrationVectorList',
+                                                  'betaNought',
+                                                  'vector_float')
+        list_gamma = cls._parse_vectorlist(et_in,
+                                           'calibrationVectorList',
+                                           'gamma',
+                                           'vector_float')
+        list_dn = cls._parse_vectorlist(et_in,
+                                        'calibrationVectorList',
+                                        'dn',
+                                        'vector_float')
 
-        return cls
+        return cls(basename_annotation, list_azimuth_time, list_line, list_pixel,
+                   list_sigma_nought, list_beta_nought, list_gamma, list_dn)
 
 
 @dataclass
@@ -1088,7 +1085,8 @@ class BurstEAP:
         Implementation from S1A documention.
 
         Code copied from ISCE2.
-
+        See https://eop-cfi.esa.int/Repo/PUBLIC/DOCUMENTATION/SYSTEM_SUPPORT_DOCS/Mission%20Convention%20Documents/MCD_custom_v4_23.pdf
+        table 10.
 
         Parameters:
         -----------

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -701,9 +701,7 @@ class SwathRfiInfo:
             azimuth_time_list,
         )
 
-
-    @classmethod
-    def extract_by_aztime(cls, aztime_start: datetime.datetime):
+    def extract_by_aztime(self, aztime_start: datetime.datetime):
         '''
         Extract the burst RFI report that is within the azimuth time of a burst
 
@@ -721,14 +719,14 @@ class SwathRfiInfo:
 
         # find the corresponding burst
         index_burst =\
-            closest_block_to_azimuth_time(np.array(cls.azimuth_time_list),
+            closest_block_to_azimuth_time(np.array(self.azimuth_time_list),
                                           aztime_start)
 
-        burst_report_out = cls.rfi_burst_report_list[index_burst]
+        burst_report_out = self.rfi_burst_report_list[index_burst]
 
         rfi_info = SimpleNamespace()
-        rfi_info.rfi_mitigation_performed = cls.rfi_mitigation_performed
-        rfi_info.rfi_mitigation_domain = cls.rfi_mitigation_domain
+        rfi_info.rfi_mitigation_performed = self.rfi_mitigation_performed
+        rfi_info.rfi_mitigation_domain = self.rfi_mitigation_domain
         rfi_info.rfi_burst_report = burst_report_out
 
         return rfi_info

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -672,12 +672,6 @@ class SwathRfiInfo:
         cls: SwathRfiInfo
             dataclass populated by this function
         '''
-
-        if ipf_version < RFI_INFO_AVAILABLE_FROM:
-            # RFI related processing is not in place
-            # return an empty dataclass
-            return None
-
         # Attempt to locate the RFI information from the input annotations
         header_lads = et_product.find('imageAnnotation/processingInformation')
         if header_lads is None:
@@ -690,22 +684,27 @@ class SwathRfiInfo:
                              'in the RFI annotation')
 
         # Start to load RFI information
-        cls.rfi_mitigation_performed =\
+        rfi_mitigation_performed =\
             header_lads.find('rfiMitigationPerformed').text
-        cls.rfi_mitigation_domain =\
+        rfi_mitigation_domain =\
             header_lads.find('rfiMitigationDomain').text
 
         num_burst_rfi_report = len(header_rfi)
-        cls.rfi_burst_report_list = [None] * num_burst_rfi_report
-        cls.azimuth_time_list = [None] * num_burst_rfi_report
+        rfi_burst_report_list = [None] * num_burst_rfi_report
+        azimuth_time_list = [None] * num_burst_rfi_report
 
         for i_burst, elem_burst in enumerate(header_rfi):
-            cls.rfi_burst_report_list[i_burst] =\
+            rfi_burst_report_list[i_burst] =\
                 element_to_dict(elem_burst)['rfiBurstReport']
-            cls.azimuth_time_list[i_burst] =\
-                cls.rfi_burst_report_list[i_burst]['azimuthTime']
+            azimuth_time_list[i_burst] =\
+                rfi_burst_report_list[i_burst]['azimuthTime']
 
-        return cls
+        return cls(
+            rfi_mitigation_performed,
+            rfi_mitigation_domain,
+            rfi_burst_report_list,
+            azimuth_time_list,
+        )
 
 
     @classmethod

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -430,56 +430,77 @@ class ProductAnnotation(AnnotationBase):
         cls: ProductAnnotation
             Parsed LADS from et_in
         '''
-
-        cls.xml_et = et_in
-
-        cls.antenna_pattern_azimuth_time = \
-            cls._parse_vectorlist('antennaPattern/antennaPatternList',
+        antenna_pattern_azimuth_time = \
+            cls._parse_vectorlist(et_in, 
+                                  'antennaPattern/antennaPatternList',
                                   'azimuthTime',
                                   'datetime')
-        cls.antenna_pattern_slant_range_time = \
-            cls._parse_vectorlist('antennaPattern/antennaPatternList',
+        antenna_pattern_slant_range_time = \
+            cls._parse_vectorlist(et_in, 
+                                  'antennaPattern/antennaPatternList',
                                   'slantRangeTime',
                                   'vector_float')
-        cls.antenna_pattern_elevation_angle = \
-            cls._parse_vectorlist('antennaPattern/antennaPatternList',
+        antenna_pattern_elevation_angle = \
+            cls._parse_vectorlist(et_in, 
+                                  'antennaPattern/antennaPatternList',
                                   'elevationAngle',
                                   'vector_float')
-        cls.antenna_pattern_elevation_pattern = \
-            cls._parse_vectorlist('antennaPattern/antennaPatternList',
+        antenna_pattern_elevation_pattern = \
+            cls._parse_vectorlist(et_in, 
+                                  'antennaPattern/antennaPatternList',
                                   'elevationPattern',
                                   'vector_float')
 
-        cls.antenna_pattern_incidence_angle = \
-            cls._parse_vectorlist('antennaPattern/antennaPatternList',
+        antenna_pattern_incidence_angle = \
+            cls._parse_vectorlist(et_in, 
+                                  'antennaPattern/antennaPatternList',
                                   'incidenceAngle',
                                   'vector_float')
 
-        cls.image_information_slant_range_time = \
-            cls._parse_scalar('imageAnnotation/imageInformation/slantRangeTime',
+        image_information_slant_range_time = \
+            cls._parse_scalar(et_in, 
+                              'imageAnnotation/imageInformation/slantRangeTime',
                               'scalar_float')
-        cls.ascending_node_time = \
-            cls._parse_scalar('imageAnnotation/imageInformation/ascendingNodeTime',
+        ascending_node_time = \
+            cls._parse_scalar(et_in, 
+                              'imageAnnotation/imageInformation/ascendingNodeTime',
                               'datetime')
-        cls.number_of_samples = \
-            cls._parse_scalar('imageAnnotation/imageInformation/numberOfSamples',
+        number_of_samples = \
+            cls._parse_scalar(et_in, 
+                              'imageAnnotation/imageInformation/numberOfSamples',
                               'scalar_int')
-        cls.number_of_samples = \
-            cls._parse_scalar('imageAnnotation/imageInformation/numberOfSamples',
+        number_of_samples = \
+            cls._parse_scalar(et_in, 
+                              'imageAnnotation/imageInformation/numberOfSamples',
                               'scalar_int')
-        cls.range_sampling_rate = \
-            cls._parse_scalar('generalAnnotation/productInformation/rangeSamplingRate',
+        range_sampling_rate = \
+            cls._parse_scalar(et_in, 
+                              'generalAnnotation/productInformation/rangeSamplingRate',
                               'scalar_float')
-        cls.slant_range_time =  \
-            cls._parse_scalar('imageAnnotation/imageInformation/slantRangeTime',
+        slant_range_time =  \
+            cls._parse_scalar(et_in, 
+                              'imageAnnotation/imageInformation/slantRangeTime',
                               'scalar_float')
 
-        cls.inst_config_id = \
+        instrument_cfg_id = \
             cls._parse_scalar('generalAnnotation/downlinkInformationList/downlinkInformation/'
                               'downlinkValues/instrumentConfigId',
                               'scalar_int')
 
-        return cls
+        return cls(
+            image_information_slant_range_time,
+            instrument_cfg_id,
+            antenna_pattern_azimuth_time,
+            antenna_pattern_slant_range_time,
+            antenna_pattern_elevation_angle,
+            antenna_pattern_elevation_pattern,
+            antenna_pattern_incidence_angle,
+            ascending_node_time,
+            number_of_samples,
+            range_sampling_rate,
+            slant_range_time,
+        )
+
 
 
 @dataclass

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -502,7 +502,6 @@ class ProductAnnotation(AnnotationBase):
         )
 
 
-
 @dataclass
 class AuxCal(AnnotationBase):
     '''AUX_CAL information for EAP correction'''
@@ -568,13 +567,13 @@ class AuxCal(AnnotationBase):
             swath_xml = calibration_params.find('swath').text
             polarisation_xml = calibration_params.find('polarisation').text
             if polarisation_xml == pol.upper() and swath_xml==str_swath.upper():
-                cls.beam_nominal_near_range = \
+                beam_nominal_near_range = \
                     float(calibration_params.
                         find('elevationAntennaPattern/beamNominalNearRange').text)
-                cls.beam_nominal_far_range = \
+                beam_nominal_far_range = \
                     float(calibration_params.
                         find('elevationAntennaPattern/beamNominalFarRange').text)
-                cls.elevation_angle_increment = \
+                elevation_angle_increment = \
                     float(calibration_params.
                         find('elevationAntennaPattern/elevationAngleIncrement').text)
 
@@ -588,37 +587,49 @@ class AuxCal(AnnotationBase):
 
                 if n_val == len(arr_eap_val):
                     # Provided in real numbers: In case of AUX_CAL for old IPFs.
-                    cls.elevation_antenna_pattern = arr_eap_val
+                    elevation_antenna_pattern = arr_eap_val
                 elif n_val*2 == len(arr_eap_val):
                     # Provided in complex numbers: In case of recent IPFs e.g. 3.10
-                    cls.elevation_antenna_pattern = arr_eap_val[0::2] + arr_eap_val[1::2] * 1.0j
+                    elevation_antenna_pattern = arr_eap_val[0::2] + arr_eap_val[1::2] * 1.0j
                 else:
                     raise ValueError('The number of values does not match. '
                                     f'n_val={n_val}, '
                                     f'#len(elevationAntennaPattern/values)={len(arr_eap_val)}')
 
-                cls.azimuth_angle_increment = \
+                azimuth_angle_increment = \
                     float(calibration_params.
                         find('azimuthAntennaPattern/azimuthAngleIncrement').text)
-                cls.azimuth_antenna_pattern = \
+                azimuth_antenna_pattern = \
                     np.array([float(token_val) for \
                               token_val in calibration_params.
                               find('azimuthAntennaPattern/values').text.split()])
 
-                cls.azimuth_antenna_element_pattern_increment = \
+                azimuth_antenna_element_pattern_increment = \
                     float(calibration_params.
                         find('azimuthAntennaElementPattern/azimuthAngleIncrement').text)
-                cls.azimuth_antenna_element_pattern = \
+                azimuth_antenna_element_pattern = \
                     np.array([float(token_val) for \
                               token_val in calibration_params.
                               find('azimuthAntennaElementPattern/values').text.split()])
 
-                cls.absolute_calibration_constant = \
+                absolute_calibration_constant = \
                     float(calibration_params.find('absoluteCalibrationConstant').text)
-                cls.noise_calibration_factor = \
+                noise_calibration_factor = \
                     float(calibration_params.find('noiseCalibrationFactor').text)
 
-        return cls
+        return cls(
+            beam_nominal_near_range,
+            beam_nominal_far_range,
+            elevation_angle_increment,
+            elevation_antenna_pattern,
+            azimuth_angle_increment,
+            azimuth_antenna_pattern,
+            azimuth_antenna_element_pattern_increment,
+            azimuth_antenna_element_pattern,
+            absolute_calibration_constant,
+            noise_calibration_factor,
+        )
+
 
 
 @dataclass

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -652,10 +652,7 @@ class SwathRfiInfo:
     azimuth_time_list: list
 
     @classmethod
-    def from_et(cls,
-                et_rfi: ET,
-                et_product: ET,
-                ipf_version: version.Version):
+    def from_et(cls, et_rfi: ET, et_product: ET):
         '''Load RFI information from etree
 
         Parameters
@@ -664,8 +661,6 @@ class SwathRfiInfo:
             XML ElementTree from RFI annotation
         et_product: ET
             XML ElementTree from product annotation
-        ipf_version: version.Version
-            IPF version of the input sentinel-1 data
 
         Returns
         -------
@@ -676,7 +671,7 @@ class SwathRfiInfo:
         header_lads = et_product.find('imageAnnotation/processingInformation')
         if header_lads is None:
             raise ValueError('Cannot locate the element in the product '
-                             'anotation where RFI mitigation info is located.')
+                             'annotation where RFI mitigation info is located.')
 
         header_rfi = et_rfi.find('rfiBurstReportList')
         if header_rfi is None:

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -146,7 +146,7 @@ class AnnotationBase:
         xml_et : lxml.etree.ElementTree
             XML tree to parse
         name_vector_list : str
-            List of dields in the xml_et to parse
+            List of fields in the xml_et to parse
         name_vector : str
             Name of the field in each elements of the `name_vector_list`
             (e.g. 'noiseLut' in 'noiseVectorList')
@@ -209,7 +209,7 @@ class CalibrationAnnotation(AnnotationBase):
     @classmethod
     def from_et(cls, et_in: ET, path_annotation: str):
         '''
-        Extracts the list of calibration informaton from etree from
+        Extracts the list of calibration information from etree from
         the Calibration Annotation Data Set (CADS).
         Parameters:
         -----------

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -276,7 +276,7 @@ class NoiseAnnotation(AnnotationBase):
     az_noise_azimuth_lut: np.ndarray
 
     @classmethod
-    def from_et(cls,et_in: ET, ipf_version: version.Version, path_annotation: str):
+    def from_et(cls, et_in: ET, ipf_version: version.Version, path_annotation: str):
         '''
         Extracts list of noise information from etree
 
@@ -290,78 +290,103 @@ class NoiseAnnotation(AnnotationBase):
         cls: NoiseAnnotation
             Parsed NADS from et_in
         '''
-
-        cls.xml_et = et_in
-        cls.basename_annotation = os.path.basename(path_annotation)
+        basename_annotation = os.path.basename(path_annotation)
 
         if ipf_version < min_ipf_version_az_noise_vector:  # legacy SAFE data
-            cls.rg_list_azimuth_time = \
-                cls._parse_vectorlist('noiseVectorList',
+            rg_list_azimuth_time = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseVectorList',
                                       'azimuthTime',
                                       'datetime')
-            cls.rg_list_line = \
-                cls._parse_vectorlist('noiseVectorList',
+            rg_list_line = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseVectorList',
                                       'line',
                                       'scalar_int')
-            cls.rg_list_pixel = \
-                cls._parse_vectorlist('noiseVectorList',
+            rg_list_pixel = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseVectorList',
                                       'pixel',
                                       'vector_int')
-            cls.rg_list_noise_range_lut = \
-                cls._parse_vectorlist('noiseVectorList',
+            rg_list_noise_range_lut = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseVectorList',
                                       'noiseLut',
                                       'vector_float')
 
-            cls.az_first_azimuth_line = None
-            cls.az_first_range_sample = None
-            cls.az_last_azimuth_line = None
-            cls.az_last_range_sample = None
-            cls.az_line = None
-            cls.az_noise_azimuth_lut = None
+            az_first_azimuth_line = None
+            az_first_range_sample = None
+            az_last_azimuth_line = None
+            az_last_range_sample = None
+            az_line = None
+            az_noise_azimuth_lut = None
 
         else:
-            cls.rg_list_azimuth_time = \
-                cls._parse_vectorlist('noiseRangeVectorList',
+            rg_list_azimuth_time = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseRangeVectorList',
                                       'azimuthTime',
                                       'datetime')
-            cls.rg_list_line = \
-                cls._parse_vectorlist('noiseRangeVectorList',
+            rg_list_line = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseRangeVectorList',
                                       'line',
                                       'scalar_int')
-            cls.rg_list_pixel = \
-                cls._parse_vectorlist('noiseRangeVectorList',
+            rg_list_pixel = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseRangeVectorList',
                                       'pixel',
                                       'vector_int')
-            cls.rg_list_noise_range_lut = \
-                cls._parse_vectorlist('noiseRangeVectorList',
+            rg_list_noise_range_lut = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseRangeVectorList',
                                       'noiseRangeLut',
                                       'vector_float')
-            cls.az_first_azimuth_line = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_first_azimuth_line = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'firstAzimuthLine',
                                       'scalar_int')[0]
-            cls.az_first_range_sample = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_first_range_sample = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'firstRangeSample',
                                       'scalar_int')[0]
-            cls.az_last_azimuth_line = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_last_azimuth_line = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'lastAzimuthLine',
                                       'scalar_int')[0]
-            cls.az_last_range_sample = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_last_range_sample = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'lastRangeSample',
                                       'scalar_int')[0]
-            cls.az_line = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_line = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'line',
                                       'vector_int')[0]
-            cls.az_noise_azimuth_lut = \
-                cls._parse_vectorlist('noiseAzimuthVectorList',
+            az_noise_azimuth_lut = \
+                cls._parse_vectorlist(et_in,
+                                      'noiseAzimuthVectorList',
                                       'noiseAzimuthLut',
                                       'vector_float')[0]
 
-        return cls
+        return cls(
+            basename_annotation,
+            rg_list_azimuth_time,
+            rg_list_line,
+            rg_list_pixel,
+            rg_list_noise_range_lut,
+            az_first_azimuth_line,
+            az_first_range_sample,
+            az_last_azimuth_line,
+            az_last_range_sample,
+            az_line,
+            az_noise_azimuth_lut,
+        )
+
 
 
 @dataclass

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -576,9 +576,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                                             'annotation/rfi/rfi-')
             with open_method(rfi_annotation_path, 'r') as f_rads:
                 tree_rads = ET.parse(f_rads)
-                burst_rfi_info_swath = SwathRfiInfo.from_et(tree_rads,
-                                                            tree_lads,
-                                                            ipf_version)
+                burst_rfi_info_swath = SwathRfiInfo.from_et(tree_rads, tree_lads)
 
         else:
             burst_rfi_info_swath = None


### PR DESCRIPTION
This is trying to prevent #122 from popping up sporadically.
This is changing the `classmethod`s in the annotation module to return instances: https://stackoverflow.com/a/14605349/4174466
the functions that are decorated with `@classmethod` are really just alternate constructors. They're meant to create a new instance. Right now, they have been changing "class attributes", which are *shared across all instances of that class*.

*Why this is a problem*
If we kick of many instance of COMPASS in different threads, each one that reads bursts instantiates these annotation classes. they are all changing the same class attribute, so it's a data race where difference function calls to `.from_et` can clobber each other.

(example to show what this looks like)

<details>

```python
In [11]: from concurrent.futures import ThreadPoolExecutor
In [12]: import time, random

In [13]: class A:
    ...:     class_thing = 0

    ...:     @classmethod
    ...:     def from_x(cls, x):
    ...:         cls.class_thing = x

    ...:         # pretend we're doing some other parsing here in the construction
    ...:         time.sleep(random.random())

    ...:         # This is supposed to print the same thing twice:
    ...:         print(f"{x}, {cls.class_thing}")

    ...:         return cls()

In [14]: a1 = A.from_x(3)
3, 3

In [15]: a2 = A.from_x(2)
2, 2
```
if you try to do this method in many threads:
```python
In [24]: tpe = ThreadPoolExecutor(max_workers=20)

In [26]: alist = list(tpe.map(A.from_x, range(20)))
3, 19
18, 19
16, 19
7, 19
2, 19
8, 19
14, 19
6, 19
9, 19
12, 19
0, 19
11, 19
19, 19
5, 19
15, 19
4, 19
1, 19
10, 19
17, 19
13, 19
```

</details>