### PR TITLE
Fix numpy >= 2.0 TypeError in polyfit

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -94,7 +94,7 @@ def polyfit(
 
     val, res, _, _ = np.linalg.lstsq(A, z, rcond=cond)
     if len(res) > 0:
-        print("Chi squared: %f" % (np.sqrt(res / (1.0 * len(z)))))
+        print("Chi squared: %f" % np.sqrt(res / (1.0 * len(z))).item())
     else:
         print("No chi squared value....")
         print("Try reducing rank of polynomial.")


### PR DESCRIPTION
## Summary

- Fix `TypeError: only 0-dimensional arrays can be converted to Python scalars` when using s1reader with numpy >= 2.0
- `np.linalg.lstsq` returns `res` as a 1-element array. In numpy >= 2.0, `%f` string formatting no longer implicitly converts arrays to scalars. Added `.item()` to explicitly extract the scalar value.


See also Piyush's PR on isce3: https://github.com/isce-framework/isce3/pull/226

## Test plan

- [x] Verified fix with numpy 2.4.1 - `polyfit` now prints chi-squared correctly instead of raising TypeError
- [x] Pre-commit hooks pass