### PR TITLE
Add Sentinel-1D (S1D) support

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -94,7 +94,7 @@ def polyfit(
 
     val, res, _, _ = np.linalg.lstsq(A, z, rcond=cond)
     if len(res) > 0:
-        print("Chi squared: %f" % (np.sqrt(res / (1.0 * len(z)))))
+        print("Chi squared: %f" % np.sqrt(res / (1.0 * len(z))).item())
     else:
         print("No chi squared value....")
         print("Try reducing rank of polynomial.")
@@ -1181,6 +1181,8 @@ class Sentinel1BurstSlc:
             orbit_number_offset = 27
         elif self.platform_id == "S1C":
             orbit_number_offset = 172
+        elif self.platform_id == "S1D":
+            orbit_number_offset = 42
         else:
             raise ValueError(f"Unknown platform_id: {self.platform_id}")
         return (self.abs_orbit_number - orbit_number_offset) % 175 + 1

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -1182,6 +1182,7 @@ class Sentinel1BurstSlc:
         elif self.platform_id == "S1C":
             orbit_number_offset = 172
         elif self.platform_id == "S1D":
+            # Note: adjust in July 26 with cal. S1D
             orbit_number_offset = 42
         else:
             raise ValueError(f"Unknown platform_id: {self.platform_id}")

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -1180,9 +1180,12 @@ class Sentinel1BurstSlc:
         elif self.platform_id == "S1B":
             orbit_number_offset = 27
         elif self.platform_id == "S1C":
-            orbit_number_offset = 172
+            # 24 June 2026, S1C orbits aligned for 6-days offset with S1D
+            if self.sensing_start < datetime.datetime(2026, 6, 24):
+                orbit_number_offset = 172
+            else:
+                orbit_number_offset = 99
         elif self.platform_id == "S1D":
-            # Note: adjust in July 26 with cal. S1D
             orbit_number_offset = 42
         else:
             raise ValueError(f"Unknown platform_id: {self.platform_id}")

--- a/src/s1reader/s1_info.py
+++ b/src/s1reader/s1_info.py
@@ -245,7 +245,7 @@ def main():
             all_files.append(path)
         elif path.is_dir():
             # Get all matching files within the directory
-            files = path.glob("S1[AB]_IW*")
+            files = path.glob("S1[ABCD]_IW*")
             all_files.extend(list(sorted(files)))
         else:
             warnings.warn(f"{path} is not a file or directory. Skipping.")


### PR DESCRIPTION
This PR extends s1-reader to support S1D, following the same pattern as the S1C support added in #144.

## Changes

**`s1_burst_slc.py`**
- `relative_orbit_number`: add S1D branch with `orbit_number_offset = 42`,
  derived from the first available S1D acquisition (abs_orbit=2389 → rel=73,
  track 73 confirmed via manifest.safe). Note: offset will be validated against
  the calibrated orbit in July 2026.
- `polyfit`: fix `numpy` 0-d array `TypeError` when calling `%f %` on
  `np.sqrt(...)` — add `.item()` to extract the Python scalar. Required for
  numpy >= 2.0.  already addressed in #150

**`s1_info.py`**
- Extend glob pattern `S1[AB]_IW*` → `S1[ABCD]_IW*` so the `s1_info` CLI
  discovers S1D SAFE files in a directory.

## Testing
Verified with S1D IW SLC acquired 2026-03-13 and 2026-04-17 (track 73, Croatia).
`load_bursts()` returns correct burst IDs, `relative_orbit_number` returns 73, and bursts geocode successfully with compass. Note: that relative orbit offset will need to be update in July, once they finish with calibration.

This if for ESA wiki page: "Sentinel-1D is currently repeating Sentinel-1C's ground track with a 1-day delay to help calibrate its integration.In July 2026, a maneuver phase will move 1C into its final configuration, re-establishing the standard 6-day revisit frequency between 1C and 1D."

S1D GSLC results browse image generated with COMPASS:
<img width="2048" height="492" alt="image" src="https://github.com/user-attachments/assets/3d65462f-0dee-45b0-b97e-79841a507012" />

Successfully generated a single-day S1C × S1D interferogram over Croatia (track 73, 27 bursts, full IW frame) to validate S1D burst loading and geocoding compatibility with compass/isce3:

**Inputs:**
 (1-day temporal baseline)
- Reference: `S1C_IW_SLC__1SDV_20260416T164125_20260416T164152_007244_00EAE8_2D6E` (RESORB)
- Secondary:  `S1D_IW_SLC__1SDV_20260417T164135_20260417T164202_002389_003E83_9EFF` (RESORB)
- DEM: Copernicus GLO-30
- Geocoding: compass, 5×10m grid, bbox [15.58, 45.55, 19.33, 47.41]

1-day interferogram from S1C and S1D:
<img width="2675" height="1035" alt="image" src="https://github.com/user-attachments/assets/cafedbc5-d887-4c52-aa33-5f5c4e3a8ca0" />




